### PR TITLE
Add NAS2D submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nas2d-core"]
+	path = nas2d-core
+	url = https://github.com/lairworks/nas2d-core.git


### PR DESCRIPTION
This adds a NAS2D submodule reference, pointing to the most recent version of NAS2D which is still compatible with this project.

Several recent changes added to NAS2D are incompatible. The main compatibility breaking changes are:
- Removing `clamp` (lairworks/nas2d-core@104f8d22631376c5a94bfc661509f2dfdcf1f7f0)
- Renaming `OGL_Renderer` to `RendererOpenGL` (lairworks/nas2d-core@6a3ef60aa385db7d97b3e76024dde2dc103dcdeb)
- Adding parameters to `Filesystem::init` (lairworks/nas2d-core@60188fd2ef5b5914647e650cfa289b46ba257228)

The version of NAS2D selected was the first commit on master before all of these changes.
