### PR TITLE
Fix memory initialization problem

### DIFF
--- a/src/Map/TileSetManager.cpp
+++ b/src/Map/TileSetManager.cpp
@@ -615,28 +615,28 @@ int TileSetManager::Load(StreamReader* stream)
 		for (int i = 0; i < numTileSets; i++)
 		{
 			// Cache the tileSet address
-			TileSetInfo* tileSet = &mTileSetInfo[i];
+			TileSetInfo& tileSet = mTileSetInfo[i];
 
 			// Read the length of the string
 			int stringLen = 0;
 			stream->read(&stringLen, 4);
 
 			// Initialize struct variables
-			tileSet->stringLength = stringLen;		// Store the string length
+			tileSet.stringLength = stringLen;		// Store the string length
 
 			if (stringLen > 0)
 			{
-				tileSet->tileSetName = new char[stringLen + 1];
-				tileSet->tileSetName[stringLen] = 0;
+				tileSet.tileSetName = new char[stringLen + 1];
+				tileSet.tileSetName[stringLen] = 0;
 
-				stream->read(tileSet->tileSetName, stringLen);
+				stream->read(tileSet.tileSetName, stringLen);
 
-				mTileSetInfo[i].wideTileSetName = tileSet->tileSetName;
+				mTileSetInfo[i].wideTileSetName = tileSet.tileSetName;
 
-				tileSet->tileSet = new TileSet(tileSet->tileSetName);
+				tileSet.tileSet = new TileSet(tileSet.tileSetName);
 
 				// Read the number of tiles stored in this tile set
-				stream->read(&tileSet->numTiles, 4);
+				stream->read(&tileSet.numTiles, 4);
 			}
 		}
 

--- a/src/Map/TileSetManager.cpp
+++ b/src/Map/TileSetManager.cpp
@@ -603,6 +603,14 @@ int TileSetManager::Load(StreamReader* stream)
 	{
 		// Allocate space for the tile set info
 		mTileSetInfo = new TileSetInfo[numTileSets];
+		// Initialize values so cleanup won't cause problems if exceptions are raised
+		for (int i = 0; i < numTileSets; i++)
+		{
+			TileSetInfo& tileSet = mTileSetInfo[i];
+			tileSet.tileSetName = NULL; // NULL string pointer
+			tileSet.numTiles = 0;       // No loaded tiles in this tile set
+			tileSet.tileSet = NULL;     // NULL ITileSet pointer
+		}
 		// Load Tile Set file list
 		for (int i = 0; i < numTileSets; i++)
 		{
@@ -615,9 +623,6 @@ int TileSetManager::Load(StreamReader* stream)
 
 			// Initialize struct variables
 			tileSet->stringLength = stringLen;		// Store the string length
-			tileSet->tileSetName = NULL;		// NULL string pointer
-			tileSet->numTiles = 0;				// No loaded tiles in this tile set
-			tileSet->tileSet = NULL;			// NULL ITileSet pointer
 
 			if (stringLen > 0)
 			{

--- a/src/Map/TileSetManager.cpp
+++ b/src/Map/TileSetManager.cpp
@@ -607,9 +607,9 @@ int TileSetManager::Load(StreamReader* stream)
 		for (int i = 0; i < numTileSets; i++)
 		{
 			TileSetInfo& tileSet = mTileSetInfo[i];
-			tileSet.tileSetName = nullptr; // NULL string pointer
-			tileSet.numTiles = 0;       // No loaded tiles in this tile set
-			tileSet.tileSet = nullptr;     // NULL ITileSet pointer
+			tileSet.tileSetName = nullptr;
+			tileSet.numTiles = 0;
+			tileSet.tileSet = nullptr;
 		}
 		// Load Tile Set file list
 		for (int i = 0; i < numTileSets; i++)

--- a/src/Map/TileSetManager.cpp
+++ b/src/Map/TileSetManager.cpp
@@ -607,9 +607,9 @@ int TileSetManager::Load(StreamReader* stream)
 		for (int i = 0; i < numTileSets; i++)
 		{
 			TileSetInfo& tileSet = mTileSetInfo[i];
-			tileSet.tileSetName = NULL; // NULL string pointer
+			tileSet.tileSetName = nullptr; // NULL string pointer
 			tileSet.numTiles = 0;       // No loaded tiles in this tile set
-			tileSet.tileSet = NULL;     // NULL ITileSet pointer
+			tileSet.tileSet = nullptr;     // NULL ITileSet pointer
 		}
 		// Load Tile Set file list
 		for (int i = 0; i < numTileSets; i++)


### PR DESCRIPTION
Some memory could be left uninitialized if an exception was raised, which would later cause problems during cleanup in the `FreeMemory` method.
