### PR TITLE
Use `clone_script:` for Git submodules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,19 @@ configuration:
 platform:
   - x86
   - x64
+clone_script:
+- ps: >-
+    if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      git clone -q --branch=$env:APPVEYOR_REPO_BRANCH https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
+      cd $env:APPVEYOR_BUILD_FOLDER
+      git checkout -qf $env:APPVEYOR_REPO_COMMIT
+    } else {
+      git clone -q https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
+      cd $env:APPVEYOR_BUILD_FOLDER
+      git fetch -q origin +refs/pull/$env:APPVEYOR_PULL_REQUEST_NUMBER/merge:
+      git checkout -qf FETCH_HEAD
+    }
+- cmd: git submodule update --init --recursive
 cache:
   - C:\tools\vcpkg\installed\
   - proj/VS2019/packages -> proj/VS2019/packages.config


### PR DESCRIPTION
Fixes #1.

This makes submodule files available before the cache is restored. This means a cache restore can depend on a file from a Git submodule. Both these steps happen before the `install:` step starts running.
