### PR TITLE
Redirect `std::cout`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,6 @@
 #include <sstream>
 #include <iostream>
 #include <fstream>
-#include <cstdio>
 
 
 #ifdef WINDOWS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <sstream>
 #include <iostream>
+#include <fstream>
 #include <cstdio>
 
 
@@ -25,13 +26,9 @@
 
 int main(int argc, char *argv[])
 {
-	// redirect log entries
-	#ifdef WINDOWS
-	FILE *stream;
-	freopen_s(&stream, "log_editor.txt", "w", stdout);
-	#else
-	FILE *stream = freopen("log_editor.txt", "w", stdout);
-	#endif
+	// Redirect output to log file
+	std::ofstream logFile("log_editor.txt");
+	std::cout.rdbuf(logFile.rdbuf());
 
 	fillCellTypes();
 	fillColorTables();
@@ -87,6 +84,5 @@ int main(int argc, char *argv[])
 		#endif
 	}
 
-	fclose(stream);
 	return 0;
 }


### PR DESCRIPTION
Closes #6.
