### PR TITLE
Implement `StreamWriter`

### DIFF
--- a/src/Stream/StreamWriter.cpp
+++ b/src/Stream/StreamWriter.cpp
@@ -1,0 +1,30 @@
+#include "StreamWriter.h"
+
+
+int StreamWriter::write(const void* buffer, size_t size)
+{
+	auto buf = (const unsigned char*)(buffer);
+
+	if (mStream.size() < mPosition + size)
+	{
+		mStream.resize(mPosition + size);
+	}
+
+	for (size_t i = 0; i < size; ++i)
+	{
+		mStream[i + mPosition] = buf[i];
+	}
+
+	mPosition += size;
+
+	return size;
+}
+
+
+/**
+ * Moved read position to \c pos.
+ */
+void StreamWriter::seek(int pos)
+{
+	mPosition += pos;
+}

--- a/src/Stream/StreamWriter.h
+++ b/src/Stream/StreamWriter.h
@@ -1,14 +1,21 @@
 #pragma once
 
-#include <NAS2D/NAS2D.h>
+#include <vector>
+
 
 class StreamWriter
 {
 public:
-	StreamWriter(NAS2D::File::RawByteStream& stream) : mStream(stream) {}
 	StreamWriter() {}
 	~StreamWriter() {}
 
+	int write(const void* buffer, size_t size);
+	void seek(int pos);
+
+	size_t size() { return mStream.size(); }
+	const unsigned char* data() { return mStream.data(); }
+
 private:
-	NAS2D::File::RawByteStream		mStream;
+	int mPosition = 0;
+	std::vector<unsigned char> mStream;
 };


### PR DESCRIPTION
Closes #20.

As `RawByteStream` is a `const` type, it can not be written to. As such, a `std::vector<unsigned char>` was used instead.
