### PR TITLE
Remove `Debug` build on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 image: Visual Studio 2019 Preview
 configuration:
   - Release
-  - Debug
 platform:
   - x86
   - x64


### PR DESCRIPTION
AppVeyor builds are simply getting too slow. This removes half of the configurations, so should help speed up the builds.
