### PR TITLE
Changes for NAS2D updates - Operator call removal

### DIFF
--- a/src/EditorState.cpp
+++ b/src/EditorState.cpp
@@ -69,7 +69,7 @@ void EditorState::initialize()
 	Utility<EventHandler>::get().quit().connect(this, &EditorState::onQuit);
 	Utility<EventHandler>::get().windowResized().connect(this, &EditorState::onWindowResized);
 
-	mSelectorRect(0, 0, TILE_SIZE, TILE_SIZE);
+	mSelectorRect = {0, 0, TILE_SIZE, TILE_SIZE};
 
 	initUi();
 
@@ -154,7 +154,7 @@ void EditorState::updateSelector()
 	int gridX = gridLocation(mMouseCoords.x(), mMap->cameraPosition().x(), r.width());
 	int gridY = gridLocation(mMouseCoords.y(), mMap->cameraPosition().y() + TILE_SIZE, r.height() - TILE_SIZE);
 
-	mSelectorRect(gridX * TILE_SIZE - rectOffsetX, gridY * TILE_SIZE - rectOffsetY, TILE_SIZE, TILE_SIZE);
+	mSelectorRect = {gridX * TILE_SIZE - rectOffsetX, gridY * TILE_SIZE - rectOffsetY, TILE_SIZE, TILE_SIZE};
 
 	// Draw Tile Selector
 	int offsetX = 0, offsetY = 0;
@@ -237,10 +237,12 @@ void EditorState::onMouseMove(int x, int y, int relX, int relY)
 		return;
 	}
 
-	mMouseCoords(x, y);
+	mMouseCoords = {x, y};
 
-	mTileHighlight(	std::clamp((x + mMap->cameraPosition().x()) / TILE_SIZE, 0, mMap->width() - 1),
-					std::clamp((y + mMap->cameraPosition().y() - TILE_SIZE) / TILE_SIZE, 0, mMap->height() - 1));
+	mTileHighlight = {
+		std::clamp((x + mMap->cameraPosition().x()) / TILE_SIZE, 0, mMap->width() - 1),
+		std::clamp((y + mMap->cameraPosition().y() - TILE_SIZE) / TILE_SIZE, 0, mMap->height() - 1)
+	};
 
 	if(mLeftButtonDown)
 	{

--- a/src/ListBox.cpp
+++ b/src/ListBox.cpp
@@ -168,7 +168,7 @@ void ListBox::onMouseMove(int x, int y, int relX, int relY)
 	// Ignore if menu is empty or invisible
 	if (empty() || !visible()) { return; }
 
-	mMouseCoords(x, y);
+	mMouseCoords = {x, y};
 }
 
 

--- a/src/Map/MapFile.cpp
+++ b/src/Map/MapFile.cpp
@@ -188,7 +188,7 @@ int MapFile::tset_index(int x, int y) const
  */
 void MapFile::updateCameraAnchorArea(int width, int height)
 {
-	mCameraAnchorArea(0, 0, mTileWidth * TILE_SIZE - width, mTileHeight * TILE_SIZE - height);
+	mCameraAnchorArea = {0, 0, mTileWidth * TILE_SIZE - width, mTileHeight * TILE_SIZE - height};
 	setCamera(mCameraPosition.x(), mCameraPosition.y());
 }
 
@@ -235,7 +235,7 @@ void MapFile::moveCamera(int x, int y)
  */
 void MapFile::setCamera(int x, int y)
 {
-	mCameraPosition(std::clamp(x, 0, mCameraAnchorArea.width()), std::clamp(y, 0, mCameraAnchorArea.height()));
+	mCameraPosition = {std::clamp(x, 0, mCameraAnchorArea.width()), std::clamp(y, 0, mCameraAnchorArea.height())};
 }
 
 

--- a/src/MiniMap.cpp
+++ b/src/MiniMap.cpp
@@ -79,7 +79,7 @@ void MiniMap::draw()
 	r.drawBoxFilled(rect().x() + 5, rect().y() + 21, (float)mMiniMap->width(), (float)mMiniMap->height(), 255, 0, 255);
 	r.drawImage(*mMiniMap, rect().x() + 5, rect().y() + 21);
 
-	mViewRect(static_cast<int>(rect().x() + 5 + (mMap->cameraPosition().x() / TILE_SIZE)), static_cast<int>(rect().y() + 21 + (mMap->cameraPosition().y() / TILE_SIZE)), static_cast<int>(r.width() / TILE_SIZE), static_cast<int>(r.height() / TILE_SIZE));
+	mViewRect = {static_cast<int>(rect().x() + 5 + (mMap->cameraPosition().x() / TILE_SIZE)), static_cast<int>(rect().y() + 21 + (mMap->cameraPosition().y() / TILE_SIZE)), static_cast<int>(r.width() / TILE_SIZE), static_cast<int>(r.height() / TILE_SIZE)};
 	r.drawBox(mViewRect, 255, 255, 255);
 }
 

--- a/src/MiniMap.cpp
+++ b/src/MiniMap.cpp
@@ -79,7 +79,7 @@ void MiniMap::draw()
 	r.drawBoxFilled(rect().x() + 5, rect().y() + 21, (float)mMiniMap->width(), (float)mMiniMap->height(), 255, 0, 255);
 	r.drawImage(*mMiniMap, rect().x() + 5, rect().y() + 21);
 
-	mViewRect(rect().x() + 5 + (mMap->cameraPosition().x() / TILE_SIZE), rect().y() + 21 + (mMap->cameraPosition().y() / TILE_SIZE), static_cast<int>(r.width() / TILE_SIZE), static_cast<int>(r.height() / TILE_SIZE));
+	mViewRect(static_cast<int>(rect().x() + 5 + (mMap->cameraPosition().x() / TILE_SIZE)), static_cast<int>(rect().y() + 21 + (mMap->cameraPosition().y() / TILE_SIZE)), static_cast<int>(r.width() / TILE_SIZE), static_cast<int>(r.height() / TILE_SIZE));
 	r.drawBox(mViewRect, 255, 255, 255);
 }
 

--- a/src/StartState.cpp
+++ b/src/StartState.cpp
@@ -64,7 +64,7 @@ void StartState::initialize()
 
 	setMessage("");
 
-	mLayoutRect(15, 15, Utility<Renderer>::get().width() - 30, Utility<Renderer>::get().height() - 40);
+	mLayoutRect(15, 15, static_cast<int>(Utility<Renderer>::get().width() - 30), static_cast<int>(Utility<Renderer>::get().height() - 40));
 
 	initUi();
 
@@ -207,7 +207,7 @@ void StartState::resizeLayout()
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	mLayoutRect(15, 15, Utility<Renderer>::get().width() - 30, Utility<Renderer>::get().height() - 40);
+	mLayoutRect(15, 15, static_cast<int>(Utility<Renderer>::get().width() - 30), static_cast<int>(Utility<Renderer>::get().height() - 40));
 
 	// =========================================
 	// = LOAD MAP PANEL

--- a/src/StartState.cpp
+++ b/src/StartState.cpp
@@ -64,7 +64,7 @@ void StartState::initialize()
 
 	setMessage("");
 
-	mLayoutRect(15, 15, static_cast<int>(Utility<Renderer>::get().width() - 30), static_cast<int>(Utility<Renderer>::get().height() - 40));
+	mLayoutRect = {15, 15, static_cast<int>(Utility<Renderer>::get().width() - 30), static_cast<int>(Utility<Renderer>::get().height() - 40)};
 
 	initUi();
 
@@ -207,7 +207,7 @@ void StartState::resizeLayout()
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	mLayoutRect(15, 15, static_cast<int>(Utility<Renderer>::get().width() - 30), static_cast<int>(Utility<Renderer>::get().height() - 40));
+	mLayoutRect = {15, 15, static_cast<int>(Utility<Renderer>::get().width() - 30), static_cast<int>(Utility<Renderer>::get().height() - 40)};
 
 	// =========================================
 	// = LOAD MAP PANEL
@@ -463,7 +463,7 @@ void StartState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
  */
 void StartState::onMouseMove(int x, int y, int relX, int relY)
 {
-	mMouseCoords(x, y);
+	mMouseCoords = {x, y};
 }
 
 
@@ -513,7 +513,7 @@ void StartState::btn64x64_Clicked()
 {
 	unsetSizeButtons();
 	mBtn64x64.toggle(true);
-	mMapSize(64, 64);
+	mMapSize = {64, 64};
 	txtMapDescription.text(MAP_64_X_64);
 }
 
@@ -522,7 +522,7 @@ void StartState::btn64x128_Clicked()
 {
 	unsetSizeButtons();
 	mBtn64x128.toggle(true);
-	mMapSize(64, 128);
+	mMapSize = {64, 128};
 	txtMapDescription.text(MAP_64_X_128);
 }
 
@@ -531,7 +531,7 @@ void StartState::btn64x256_Clicked()
 {
 	unsetSizeButtons();
 	mBtn64x256.toggle(true);
-	mMapSize(64, 256);
+	mMapSize = {64, 256};
 	txtMapDescription.text(MAP_64_X_256);
 }
 
@@ -540,7 +540,7 @@ void StartState::btn128x128_Clicked()
 {
 	unsetSizeButtons();
 	mBtn128x128.toggle(true);
-	mMapSize(128, 128);
+	mMapSize = {128, 128};
 	txtMapDescription.text(MAP_128_X_128);
 }
 
@@ -549,7 +549,7 @@ void StartState::btn128x64_Clicked()
 {
 	unsetSizeButtons();
 	mBtn128x64.toggle(true);
-	mMapSize(128, 64);
+	mMapSize = {128, 64};
 	txtMapDescription.text(MAP_128_X_64);
 }
 
@@ -558,7 +558,7 @@ void StartState::btn128x256_Clicked()
 {
 	unsetSizeButtons();
 	mBtn128x256.toggle(true);
-	mMapSize(128, 256);
+	mMapSize = {128, 256};
 	txtMapDescription.text(MAP_128_X_256);
 }
 
@@ -567,7 +567,7 @@ void StartState::btn256x256_Clicked()
 {
 	unsetSizeButtons();
 	mBtn256x256.toggle(true);
-	mMapSize(256, 256);
+	mMapSize = {256, 256};
 	txtMapDescription.text(MAP_256_X_256);
 }
 
@@ -576,7 +576,7 @@ void StartState::btn256x128_Clicked()
 {
 	unsetSizeButtons();
 	mBtn256x128.toggle(true);
-	mMapSize(256, 128);
+	mMapSize = {256, 128};
 	txtMapDescription.text(MAP_256_X_128);
 }
 
@@ -585,7 +585,7 @@ void StartState::btn512x256_Clicked()
 {
 	unsetSizeButtons();
 	mBtn512x256.toggle(true);
-	mMapSize(512, 256);
+	mMapSize = {512, 256};
 	txtMapDescription.text(MAP_512_X_256);
 }
 

--- a/src/TilePalette.cpp
+++ b/src/TilePalette.cpp
@@ -30,7 +30,7 @@ void TilePalette::_init()
 	int yPosition = rect().y() + rect().height() - 23;
 
 	Renderer& r = Utility<Renderer>::get();
-	_rect()(r.width() - PALETTE_DIMENSIONS.x() - 2, r.height() - PALETTE_DIMENSIONS.y() - 2, static_cast<float>(PALETTE_DIMENSIONS.x()), static_cast<float>(PALETTE_DIMENSIONS.y()));
+	_rect() = {r.width() - PALETTE_DIMENSIONS.x() - 2, r.height() - PALETTE_DIMENSIONS.y() - 2, static_cast<float>(PALETTE_DIMENSIONS.x()), static_cast<float>(PALETTE_DIMENSIONS.y())};
 
 	text("Tile Palette");
 }

--- a/src/TilePalette.cpp
+++ b/src/TilePalette.cpp
@@ -30,7 +30,7 @@ void TilePalette::_init()
 	int yPosition = rect().y() + rect().height() - 23;
 
 	Renderer& r = Utility<Renderer>::get();
-	_rect()(r.width() - PALETTE_DIMENSIONS.x() - 2, r.height() - PALETTE_DIMENSIONS.y() - 2, PALETTE_DIMENSIONS.x(), PALETTE_DIMENSIONS.y());
+	_rect()(r.width() - PALETTE_DIMENSIONS.x() - 2, r.height() - PALETTE_DIMENSIONS.y() - 2, static_cast<float>(PALETTE_DIMENSIONS.x()), static_cast<float>(PALETTE_DIMENSIONS.y()));
 
 	text("Tile Palette");
 }

--- a/src/ToolBar.cpp
+++ b/src/ToolBar.cpp
@@ -54,7 +54,7 @@ void ToolBar::initUi()
 	btnFillContiguous.position(btnFill.positionX() - 30, 40);
 	btnFillContiguous.visible(false);
 
-	mFloodFillExtendedArea((int)btnFillContiguous.positionX() - 4, (int)btnFillContiguous.positionY() - 4, 104, (int)btnFillContiguous.height() + 8);
+	mFloodFillExtendedArea(static_cast<int>(btnFillContiguous.positionX() - 4), static_cast<int>(btnFillContiguous.positionY() - 4), 104, static_cast<int>(btnFillContiguous.height() + 8));
 
 	btnErase.image("sys/erase.png");
 	btnErase.type(Button::BUTTON_TOGGLE);
@@ -164,7 +164,7 @@ void drawSeparator(Button& btn, int margin)
 void ToolBar::update()
 {
 	Renderer& r = Utility<Renderer>::get();
-	bevelBox(0, 0, (int)r.width(), (int)height());
+	bevelBox(0, 0, static_cast<int>(r.width()), static_cast<int>(height()));
 
 	btnSave.update();
 

--- a/src/ToolBar.cpp
+++ b/src/ToolBar.cpp
@@ -54,7 +54,7 @@ void ToolBar::initUi()
 	btnFillContiguous.position(btnFill.positionX() - 30, 40);
 	btnFillContiguous.visible(false);
 
-	mFloodFillExtendedArea(static_cast<int>(btnFillContiguous.positionX() - 4), static_cast<int>(btnFillContiguous.positionY() - 4), 104, static_cast<int>(btnFillContiguous.height() + 8));
+	mFloodFillExtendedArea = {static_cast<int>(btnFillContiguous.positionX() - 4), static_cast<int>(btnFillContiguous.positionY() - 4), 104, static_cast<int>(btnFillContiguous.height() + 8)};
 
 	btnErase.image("sys/erase.png");
 	btnErase.type(Button::BUTTON_TOGGLE);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -75,7 +75,7 @@ void Window::onMouseUp(NAS2D::EventHandler::MouseButton button, int x, int y)
 
 void Window::onMouseMotion(int x, int y, int dX, int dY)
 {
-	mMouseCoords(x, y);
+	mMouseCoords = {x, y};
 
 	if (!visible()) { return; }
 


### PR DESCRIPTION
This updates op2-landlord for the upstream changes to NAS2D, where operator call (`operator()`) was remove from both `Point` and `Rectangle`.

----

Master has a broken Windows AppVeyor build. It requires an upstream change to NAS2D to fix. Failures are expected to be seen from the Windows CI builds.

Note that these updates are needed before the upstream Windows fix is merged. Since NAS2D has already merged the changes to remove operator call, trying to update NAS2D to include the Windows build fix will also include the removal of operator call. Hence without these changes, such an update would simply leave all builds broken.
