### PR TITLE
Fix AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,20 +18,14 @@ clone_script:
     }
 - cmd: git submodule update --init --recursive
 cache:
-  - C:\tools\vcpkg\installed\
+  - C:\tools\vcpkg\installed\ -> nas2d-core/InstallVcpkgDeps.bat
   - proj/VS2019/packages -> proj/VS2019/packages.config
   - nas2d-core/proj/vs2019/packages -> nas2d-core/proj/vs2019/packages.config
 install:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - git submodule update --init --recursive
+  - vcpkg integrate install
+  - call nas2d-core/InstallVcpkgDeps.bat
   - nuget restore proj/VS2019
   - nuget restore nas2d-core/proj/vs2019
-  - vcpkg integrate install
-  - vcpkg install physfs:x86-windows
-  - vcpkg install physfs:x64-windows
-  - vcpkg install glew:x86-windows
-  - vcpkg install glew:x64-windows
-  - vcpkg install gtest:x86-windows
-  - vcpkg install gtest:x64-windows
+  - set APPVEYOR_SAVE_CACHE_ON_ERROR=true
 build:
   project: proj/VS2019/OP2-Landlord.sln

--- a/proj/VS2019/OP2-Landlord.vcxproj
+++ b/proj/VS2019/OP2-Landlord.vcxproj
@@ -79,9 +79,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>..\..\nas2d-core\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>..\..\nas2d-core\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
Updates NAS2D submodule for upstream build config fix, so it can properly find `InstallVcpkgDeps.bat`.

Updates `LibraryPath` for x64 configuration so it can find `NAS2D.lib`, which was moved.

Updates AppVeyor config to make use of the new `InstallVcpkgDeps.bat` file, and to remove old cruft for the `git submodule update`.
