### PR TITLE
Remove Signal parameter count

### DIFF
--- a/src/Button.h
+++ b/src/Button.h
@@ -19,7 +19,7 @@ public:
 	};
 
 	typedef NAS2D::Signals::Signal<> ClickCallback;
-	typedef NAS2D::Signals::Signal1<bool> PressCallback;
+	typedef NAS2D::Signals::Signal<bool> PressCallback;
 
 public:
 	Button();

--- a/src/Button.h
+++ b/src/Button.h
@@ -18,7 +18,7 @@ public:
 		BUTTON_TOGGLE
 	};
 
-	typedef NAS2D::Signals::Signal0<void> ClickCallback;
+	typedef NAS2D::Signals::Signal<> ClickCallback;
 	typedef NAS2D::Signals::Signal1<bool> PressCallback;
 
 public:

--- a/src/Control.h
+++ b/src/Control.h
@@ -20,9 +20,9 @@ using namespace NAS2D;
 class Control
 {
 public:
-	typedef NAS2D::Signals::Signal1<Control*> ResizeCallback;
-	typedef NAS2D::Signals::Signal1<Control*> TextChangedCallback;
-	typedef NAS2D::Signals::Signal2<float, float> PositionChangedCallback;
+	typedef NAS2D::Signals::Signal<Control*> ResizeCallback;
+	typedef NAS2D::Signals::Signal<Control*> TextChangedCallback;
+	typedef NAS2D::Signals::Signal<float, float> PositionChangedCallback;
 
 public:
 

--- a/src/ListBox.h
+++ b/src/ListBox.h
@@ -12,7 +12,7 @@
 class ListBox: public UIContainer
 {
 public:
-	typedef NAS2D::Signals::Signal0<void> SelectionChangedCallback;
+	typedef NAS2D::Signals::Signal<> SelectionChangedCallback;
 
 public:
 	ListBox();

--- a/src/Slider.h
+++ b/src/Slider.h
@@ -21,7 +21,7 @@
 class Slider : public Control
 {
 public:
-	typedef NAS2D::Signals::Signal1<double> ValueChangedCallback; /*!< type for Callback on value changed. */
+	typedef NAS2D::Signals::Signal<double> ValueChangedCallback; /*!< type for Callback on value changed. */
 
 public:
 	Slider();

--- a/src/TextArea.h
+++ b/src/TextArea.h
@@ -12,7 +12,7 @@ class TextArea : public Control
 {
 public:
 
-	typedef NAS2D::Signals::Signal0<void> ClickCallback;
+	typedef NAS2D::Signals::Signal<> ClickCallback;
 
 	TextArea();
 	virtual ~TextArea();

--- a/src/ToolBar.h
+++ b/src/ToolBar.h
@@ -25,7 +25,7 @@ public:
 		TOOLBAR_QUIT
 	};
 
-	typedef NAS2D::Signals::Signal1<ToolBarAction> ToolBarEvent;
+	typedef NAS2D::Signals::Signal<ToolBarAction> ToolBarEvent;
 
 public:
 	ToolBar();


### PR DESCRIPTION
Remove `Signal` placeholder `void`, and `Signal` parameter counts:
- `Signal0<void>` => `Signal<>`
- `Signal1<int>` => `Signal<int>`
