### PR TITLE
Mount a write folder

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char *argv[])
 	{
 		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OP2-Landlord", "Outpost Universe");
 		f.mount("data");
+		f.mountReadWrite(f.prefPath());
 
 		Configuration& cf = Utility<Configuration>::get();
 		cf.load("config.xml");


### PR DESCRIPTION
This fixes the error introduced by PR #34, that was discovered post merge.

A NAS2D update brought in a change that removed default mounting. The project must now manually mount a write folder, or writes will cause errors.

This update prevents crashes during startup. The crashes are particularly troublesome as they produce no obvious diagnostic output.
