### PR TITLE
Remove string_format

### DIFF
--- a/src/EditorState.cpp
+++ b/src/EditorState.cpp
@@ -119,7 +119,8 @@ State* EditorState::update()
 	updateSelector();
 	updateUI();
 
-	r.drawTextShadow(mBoldFont, string_format("World Tile: %i, %i", mTileHighlight.x(), mTileHighlight.y()), 5, r.height() - 30, 1, 255, 255, 255, 0, 0, 0);
+	const auto text = string_format("World Tile: %i, %i", mTileHighlight.x(), mTileHighlight.y());
+	r.drawTextShadow(mBoldFont, text, 5, r.height() - 30, 1, 255, 255, 255, 0, 0, 0);
 	r.drawTextShadow(mBoldFont, "Map File: " + mMapSavePath, 5.0f, r.height() - mBoldFont.height(), 1, 255, 255, 255, 0, 0, 0);
 
 	return mReturnState;

--- a/src/EditorState.cpp
+++ b/src/EditorState.cpp
@@ -119,7 +119,7 @@ State* EditorState::update()
 	updateSelector();
 	updateUI();
 
-	const auto text = string_format("World Tile: %i, %i", mTileHighlight.x(), mTileHighlight.y());
+	const auto text = "World Tile: " + std::to_string(mTileHighlight.x()) + ", " + std::to_string(mTileHighlight.y());
 	r.drawTextShadow(mBoldFont, text, 5, r.height() - 30, 1, 255, 255, 255, 0, 0, 0);
 	r.drawTextShadow(mBoldFont, "Map File: " + mMapSavePath, 5.0f, r.height() - mBoldFont.height(), 1, 255, 255, 255, 0, 0, 0);
 

--- a/src/Slider.cpp
+++ b/src/Slider.cpp
@@ -300,7 +300,7 @@ void Slider::draw()
 
 	if (fontSet() && mDisplayPosition && mMouseHoverSlide)
 	{
-		textHover = string_format("%i / %i", static_cast<int>(thumbPosition()), static_cast<int>(mLenght));
+		textHover = std::to_string(static_cast<int>(thumbPosition())) + " / " + std::to_string(static_cast<int>(mLenght));
 		_w = font().width(textHover) + 4;
 		_h = font().height() + 4;
 

--- a/src/ToolBar.cpp
+++ b/src/ToolBar.cpp
@@ -186,7 +186,7 @@ void ToolBar::update()
 
 	r.drawBoxFilled(btnSpinnerUp.rect().x() - 21, btnSpinnerUp.rect().y(), 20, 28, 255, 255, 255);
 	r.drawBox(btnSpinnerUp.rect().x() - 21, btnSpinnerUp.rect().y(), 20, 28, 0, 0, 0);
-	r.drawText(mFont, NAS2D::string_format("%i", static_cast<int>(mBrush.width())), btnSpinnerUp.rect().x() - 18 + (mFont.width(NAS2D::string_format("%i", static_cast<int>(mBrush.width()))) / 2), 12, 0, 0, 0);
+	r.drawText(mFont, std::to_string(static_cast<int>(mBrush.width())), btnSpinnerUp.rect().x() - 18 + (mFont.width(NAS2D::string_format("%i", static_cast<int>(mBrush.width()))) / 2), 12, 0, 0, 0);
 
 	btnSpinnerUp.update();
 	btnSpinnerDown.update();


### PR DESCRIPTION
Remove all uses of `string_format`. Uses `std::to_string` as a replacement.
