### PR TITLE
Use packed parameter methods

### DIFF
--- a/OP2-Landlord/Common.cpp
+++ b/OP2-Landlord/Common.cpp
@@ -18,7 +18,7 @@ void bevelBox(int x, int y, int w, int h, bool sunk, const Color& bgcolor)
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	r.drawBoxFilled(x, y, w, h, bgcolor.red(), bgcolor.green(), bgcolor.blue());
+	r.drawBoxFilled(NAS2D::Rectangle<int>{x, y, w, h}, bgcolor);
 
 	if (!sunk)
 	{

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -211,8 +211,8 @@ void ListBox::update()
 	// draw boundaries of the widget
 	auto boxBounds = rect();
 	boxBounds.width() = mItemWidth;
-	r.drawBox(boxBounds, 0, 0, 0, 100);
-	r.drawBoxFilled(boxBounds, 225, 225, 0, 85);
+	r.drawBox(boxBounds, Color{0, 0, 0, 100});
+	r.drawBoxFilled(boxBounds, Color{225, 225, 0, 85});
 
 	// Highlight currently selected file
 	if (mItemMin <= mCurrentSelection && mCurrentSelection < mItemMax)

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -223,8 +223,8 @@ void ListBox::update()
 	// display actuals values that are ment to be
 	for (int i = mItemMin; i < mItemMax; i++)
 	{
-		int itemY = rect().y() + ((i - mItemMin) * mLineHeight);
-		r.drawTextShadow(font(), mItems[i], rect().x(), itemY, 1, mText.red(), mText.green(), mText.blue(), 0, 0, 0);
+		const auto position = Point{rect().x(),rect().y() + ((i - mItemMin) * mLineHeight)};
+		r.drawTextShadow(font(), mItems[i], position, {1, 1}, mText, Color::Black);
 	}
 
 	r.drawBox(rect(), NAS2D::Color::Black);

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -6,9 +6,10 @@
 /**
  * C'tor
  */
-ListBox::ListBox():	mText(Color::White),
-					mHighlightBg(Color::Green),
-					mHighlightText(Color::White)
+ListBox::ListBox() :
+	mText(Color::White),
+	mHighlightBg(Color::Green),
+	mHighlightText(Color::White)
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
 	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -216,7 +216,7 @@ void ListBox::update()
 	if (mItemMin <= mCurrentSelection && mCurrentSelection < mItemMax)
 	{
 		itemY = rect().y() + ((mCurrentSelection - mCurrentOffset)  * mLineHeight);
-		r.drawBoxFilled(rect().x(), itemY, mItemWidth, mLineHeight, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), 80);
+		r.drawBoxFilled(rect().x(), itemY, mItemWidth, mLineHeight, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), mHighlightBg.alpha());
 	}
 
 	// display actuals values that are ment to be

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -209,8 +209,10 @@ void ListBox::update()
 	int itemY;
 
 	// draw boundaries of the widget
-	r.drawBox(rect().x(), rect().y(), mItemWidth, rect().height(), 0, 0, 0, 100);
-	r.drawBoxFilled(rect().x(), rect().y(), mItemWidth, rect().height(), 225, 225, 0, 85);
+	auto boxBounds = rect();
+	boxBounds.width() = mItemWidth;
+	r.drawBox(boxBounds, 0, 0, 0, 100);
+	r.drawBoxFilled(boxBounds, 225, 225, 0, 85);
 
 	// Highlight currently selected file
 	if (mItemMin <= mCurrentSelection && mCurrentSelection < mItemMax)

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -203,7 +203,7 @@ void ListBox::update()
 
 	Renderer& r = Utility<Renderer>::get();
 
-	r.drawBoxFilled(rect(), 0, 0, 0);
+	r.drawBoxFilled(rect(), NAS2D::Color::Black);
 
 	int itemY;
 
@@ -225,7 +225,7 @@ void ListBox::update()
 		r.drawTextShadow(font(), mItems[i], rect().x(), itemY, 1, mText.red(), mText.green(), mText.blue(), 0, 0, 0);
 	}
 
-	r.drawBox(rect(), 0, 0, 0);
+	r.drawBox(rect(), NAS2D::Color::Black);
 
 	// draw the slider if needed
 	mSlider.update();

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -215,10 +215,11 @@ void ListBox::update()
 	r.drawBoxFilled(boxBounds, Color{225, 225, 0, 85});
 
 	// Highlight currently selected file
+	boxBounds.height() = mLineHeight;
 	if (mItemMin <= mCurrentSelection && mCurrentSelection < mItemMax)
 	{
-		itemY = rect().y() + ((mCurrentSelection - mCurrentOffset)  * mLineHeight);
-		r.drawBoxFilled(rect().x(), itemY, mItemWidth, mLineHeight, mHighlightBg.red(), mHighlightBg.green(), mHighlightBg.blue(), mHighlightBg.alpha());
+		boxBounds.y() = rect().y() + ((mCurrentSelection - mCurrentOffset)  * mLineHeight);
+		r.drawBoxFilled(boxBounds, mHighlightBg);
 	}
 
 	// display actuals values that are ment to be

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -8,7 +8,7 @@
  */
 ListBox::ListBox() :
 	mText(Color::White),
-	mHighlightBg(Color::Green),
+	mHighlightBg(Color{0, 255, 0, 80}),
 	mHighlightText(Color::White)
 {
 	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -206,8 +206,6 @@ void ListBox::update()
 
 	r.drawBoxFilled(rect(), NAS2D::Color::Black);
 
-	int itemY;
-
 	// draw boundaries of the widget
 	auto boxBounds = rect();
 	boxBounds.width() = mItemWidth;
@@ -225,7 +223,7 @@ void ListBox::update()
 	// display actuals values that are ment to be
 	for (int i = mItemMin; i < mItemMax; i++)
 	{
-		itemY = rect().y() + ((i - mItemMin) * mLineHeight);
+		int itemY = rect().y() + ((i - mItemMin) * mLineHeight);
 		r.drawTextShadow(font(), mItems[i], rect().x(), itemY, 1, mText.red(), mText.green(), mText.blue(), 0, 0, 0);
 	}
 


### PR DESCRIPTION
Use packed parameter methods, particularly for those involving `Color`, and which access individual components of `Color` objects.

These changes help prepare for a NAS2D submodule update. When the `Color` fields were made public, it broke source code compatibility for references to the individual color components of a `Color` struct. By restructuring code to avoid referencing these components in the client code, it avoids source code breaks when the submodule is updated.
