### PR TITLE
Update NAS2D submodule for removal of Configuration auto save

### DIFF
--- a/OP2-Landlord/main.cpp
+++ b/OP2-Landlord/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
 			cf.graphicsWidth(1000);
 			cf.graphicsHeight(650);
 		}
-		cf.save();
+		cf.save("config.xml");
 
 		// All utilities must be initialized or exceptions are thrown when their Null
 		// variants aren't in place.


### PR DESCRIPTION
Client code must now call `Configuration::save` explicitly, and with a filename.
