### PR TITLE
Point Rectangle BaseTypes

### DIFF
--- a/OP2-Landlord/Button.cpp
+++ b/OP2-Landlord/Button.cpp
@@ -75,7 +75,7 @@ void Button::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point<int> click{x, y};
+		Point click{x, y};
 
 
 		if(rect().contains(click))
@@ -102,7 +102,7 @@ void Button::onMouseUp(EventHandler::MouseButton button, int x, int y)
 
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
-		Point<int> click{x, y};
+		Point click{x, y};
 		
 		if(mType == BUTTON_NORMAL)
 		{

--- a/OP2-Landlord/Common.cpp
+++ b/OP2-Landlord/Common.cpp
@@ -131,5 +131,5 @@ bool pointInRect_f(int x, int y, const Rectangle<float>& rect)
  */
 bool pointInRect_f(int x, int y, float rectX, float rectY, float rectW, float rectH)
 {
-	return pointInRect_f(x, y, NAS2D::Rectangle{rectX, rectY, rectW, rectH});
+	return pointInRect_f(x, y, {rectX, rectY, rectW, rectH});
 }

--- a/OP2-Landlord/Common.cpp
+++ b/OP2-Landlord/Common.cpp
@@ -122,7 +122,7 @@ int gridLocation(int point, int cameraPoint, int viewportDimension)
  */
 bool pointInRect_f(int x, int y, const Rectangle<float>& rect)
 {
-	return static_cast<NAS2D::Rectangle<int>>(rect).contains(NAS2D::Point<int>{x, y});
+	return static_cast<NAS2D::Rectangle<int>>(rect).contains(NAS2D::Point{x, y});
 }
 
 

--- a/OP2-Landlord/Common.cpp
+++ b/OP2-Landlord/Common.cpp
@@ -18,7 +18,7 @@ void bevelBox(int x, int y, int w, int h, bool sunk, const Color& bgcolor)
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	r.drawBoxFilled(NAS2D::Rectangle<int>{x, y, w, h}, bgcolor);
+	r.drawBoxFilled(NAS2D::Rectangle{x, y, w, h}, bgcolor);
 
 	if (!sunk)
 	{
@@ -131,5 +131,5 @@ bool pointInRect_f(int x, int y, const Rectangle<float>& rect)
  */
 bool pointInRect_f(int x, int y, float rectX, float rectY, float rectW, float rectH)
 {
-	return pointInRect_f(x, y, NAS2D::Rectangle<float>{rectX, rectY, rectW, rectH});
+	return pointInRect_f(x, y, NAS2D::Rectangle{rectX, rectY, rectW, rectH});
 }

--- a/OP2-Landlord/Common.cpp
+++ b/OP2-Landlord/Common.cpp
@@ -122,7 +122,7 @@ int gridLocation(int point, int cameraPoint, int viewportDimension)
  */
 bool pointInRect_f(int x, int y, const Rectangle<float>& rect)
 {
-	return static_cast<NAS2D::Rectangle<int>>(rect).contains(NAS2D::Point{x, y});
+	return rect.to<int>().contains(NAS2D::Point{x, y});
 }
 
 

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -154,9 +154,9 @@ void ListBox::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	// Ignore if menu is empty or invisible
 	if (empty() || !visible()) { return; }
 
-	if (!rect().contains(Point<int>{x, y})) { return; }
+	if (!rect().contains(Point{x, y})) { return; }
 
-	if (mSlider.visible() && mSlider.rect().contains(Point<int>{x, y}))
+	if (mSlider.visible() && mSlider.rect().contains(Point{x, y}))
 		return;		// if the mouse is on the slider then the slider should handle that
 
 	int idx = ((y - (int)rect().y()) / (font().height() + 2)) % ((int)rect().height() / (font().height() + 2)) + mCurrentOffset;

--- a/OP2-Landlord/MiniMap.cpp
+++ b/OP2-Landlord/MiniMap.cpp
@@ -39,7 +39,7 @@ void MiniMap::mouseDown(EventHandler::MouseButton b, int x, int y)
 
 	const auto startPoint = NAS2D::Point{rect().x() + 4, rect().y() + 21}.to<int>();
 	const auto miniMapBounds = NAS2D::Rectangle{startPoint.x, startPoint.y, mMiniMap->width(), mMiniMap->height()};
-	if (miniMapBounds.contains(NAS2D::Point{x, y}))
+	if (miniMapBounds.contains({x, y}))
 	{
 		mMovingCamera = true;
 		adjustCamera(x, y);

--- a/OP2-Landlord/MiniMap.cpp
+++ b/OP2-Landlord/MiniMap.cpp
@@ -38,7 +38,7 @@ void MiniMap::mouseDown(EventHandler::MouseButton b, int x, int y)
 	if (!mMiniMap) { return; }
 
 	const auto startPoint = static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{rect().x() + 4, rect().y() + 21});
-	const auto miniMapBounds = NAS2D::Rectangle<int>{startPoint.x, startPoint.y, mMiniMap->width(), mMiniMap->height()};
+	const auto miniMapBounds = NAS2D::Rectangle{startPoint.x, startPoint.y, mMiniMap->width(), mMiniMap->height()};
 	if (miniMapBounds.contains(NAS2D::Point{x, y}))
 	{
 		mMovingCamera = true;

--- a/OP2-Landlord/MiniMap.cpp
+++ b/OP2-Landlord/MiniMap.cpp
@@ -37,7 +37,7 @@ void MiniMap::mouseDown(EventHandler::MouseButton b, int x, int y)
 
 	if (!mMiniMap) { return; }
 
-	const auto startPoint = static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{rect().x() + 4, rect().y() + 21});
+	const auto startPoint = NAS2D::Point{rect().x() + 4, rect().y() + 21}.to<int>();
 	const auto miniMapBounds = NAS2D::Rectangle{startPoint.x, startPoint.y, mMiniMap->width(), mMiniMap->height()};
 	if (miniMapBounds.contains(NAS2D::Point{x, y}))
 	{

--- a/OP2-Landlord/TextField.cpp
+++ b/OP2-Landlord/TextField.cpp
@@ -297,7 +297,7 @@ void TextField::onMouseDown(EventHandler::MouseButton button, int x, int y)
 	if(!fontSet())
 		return;
 
-	if(!rect().contains(Point<int>{x, y}))
+	if(!rect().contains(Point{x, y}))
 	{
 		hasFocus(false);
 		return;

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -50,7 +50,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 
 	const auto windowBounds = rect().to<int>();
 	const auto titleBarBounds = NAS2D::Rectangle{windowBounds.x(), windowBounds.y(), windowBounds.width(), titleBarHeight()};
-	if (titleBarBounds.contains(NAS2D::Point{x, y}))
+	if (titleBarBounds.contains({x, y}))
 	{
 		mDragging = true;
 		return;

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -49,7 +49,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 	if((button != EventHandler::MouseButton::BUTTON_LEFT)) { return; }
 
 	const auto windowBounds = static_cast<NAS2D::Rectangle<int>>(rect());
-	const auto titleBarBounds = NAS2D::Rectangle<int>{windowBounds.x(), windowBounds.y(), windowBounds.width(), titleBarHeight()};
+	const auto titleBarBounds = NAS2D::Rectangle{windowBounds.x(), windowBounds.y(), windowBounds.width(), titleBarHeight()};
 	if (titleBarBounds.contains(NAS2D::Point{x, y}))
 	{
 		mDragging = true;

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -50,7 +50,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 
 	const auto windowBounds = static_cast<NAS2D::Rectangle<int>>(rect());
 	const auto titleBarBounds = NAS2D::Rectangle<int>{windowBounds.x(), windowBounds.y(), windowBounds.width(), titleBarHeight()};
-	if (titleBarBounds.contains(NAS2D::Point<int>{x, y}))
+	if (titleBarBounds.contains(NAS2D::Point{x, y}))
 	{
 		mDragging = true;
 		return;

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -48,7 +48,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, int x, int y)
 
 	if((button != EventHandler::MouseButton::BUTTON_LEFT)) { return; }
 
-	const auto windowBounds = static_cast<NAS2D::Rectangle<int>>(rect());
+	const auto windowBounds = rect().to<int>();
 	const auto titleBarBounds = NAS2D::Rectangle{windowBounds.x(), windowBounds.y(), windowBounds.width(), titleBarHeight()};
 	if (titleBarBounds.contains(NAS2D::Point{x, y}))
 	{


### PR DESCRIPTION
Omit `Point` and `Rectangle` types and `BaseType`s where they will be inferred. Replace `static_cast` with `.to<NewBaseType>()` calls.
