### PR TITLE
Improve const correctness of Font

### DIFF
--- a/OP2-Landlord/Control.cpp
+++ b/OP2-Landlord/Control.cpp
@@ -29,7 +29,7 @@ Control::~Control()
  *			by Control. The Font passed to Control should not be allowed to go
  *			out of scope until the Control is destroyed.
  */
-void Control::font(Font& font)
+void Control::font(const Font& font)
 {
 	mFont = &font;
 
@@ -41,7 +41,7 @@ void Control::font(Font& font)
  * Internal function to provide access to the Font object
  * to derived objects.
  */
-Font& Control::font()
+const Font& Control::font()
 {
 	return *mFont;
 }

--- a/OP2-Landlord/Control.h
+++ b/OP2-Landlord/Control.h
@@ -29,7 +29,7 @@ public:
 	Control();
 	virtual ~Control();
 
-	void font(Font& font);
+	void font(const Font& font);
 
 	void position(const Point<float>& pos);
 	void position(float x, float y);
@@ -98,7 +98,7 @@ protected:
 	virtual void onTextChanged() { mTextChanged(this); };
 	virtual void onFontChanged() {};
 
-	Font& font();
+	const Font& font();
 	bool fontSet() const;
 
 	Rectangle<float>& _rect();
@@ -115,7 +115,7 @@ private:
 
 	virtual void draw() {};
 
-	Font*			mFont;			/**< Pointer to a Font object. Control DOES NOT own the pointer. */
+	const Font*			mFont;			/**< Pointer to a Font object. Control DOES NOT own the pointer. */
 
 	std::string		mText;			/**< Internal text string. */
 

--- a/OP2-Landlord/EditorState.h
+++ b/OP2-Landlord/EditorState.h
@@ -61,8 +61,8 @@ private:
 
 private:
 	Timer			mTimer;
-	Font			mFont{"fonts/opensans.ttf", 12};
-	Font			mBoldFont{"fonts/opensans-bold.ttf", 12};
+	const Font mFont{"fonts/opensans.ttf", 12};
+	const Font mBoldFont{"fonts/opensans-bold.ttf", 12};
 
 	MapFile*		mMap = nullptr;				/**< Map object. */
 

--- a/OP2-Landlord/EditorState.h
+++ b/OP2-Landlord/EditorState.h
@@ -2,6 +2,7 @@
 
 #include "NAS2D/NAS2D.h"
 
+#include "Fonts.h"
 #include "MiniMap.h"
 #include "TileGroups.h"
 #include "TilePalette.h"
@@ -61,8 +62,8 @@ private:
 
 private:
 	Timer			mTimer;
-	const Font mFont{"fonts/opensans.ttf", 12};
-	const Font mBoldFont{"fonts/opensans-bold.ttf", 12};
+	const Font& mFont = fontCache.load("fonts/opensans.ttf", 12);
+	const Font& mBoldFont = fontCache.load("fonts/opensans-bold.ttf", 12);
 
 	MapFile*		mMap = nullptr;				/**< Map object. */
 

--- a/OP2-Landlord/Fonts.h
+++ b/OP2-Landlord/Fonts.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <NAS2D/Resources/Font.h>
+#include <NAS2D/Resources/ResourceCache.h>
+
+
+inline ResourceCache<NAS2D::Font, std::string, unsigned int> fontCache;

--- a/OP2-Landlord/StartState.cpp
+++ b/OP2-Landlord/StartState.cpp
@@ -35,9 +35,8 @@ void setMessage(const std::string& msg)
 /**
  * C'tpr
  */
-StartState::StartState():	mFont("fonts/opensans.ttf", 12),
-							mBoldFont("fonts/opensans-bold.ttf", 12),
-							mMapSize{64, 64}
+StartState::StartState() :
+	mMapSize{64, 64}
 {}
 
 

--- a/OP2-Landlord/StartState.h
+++ b/OP2-Landlord/StartState.h
@@ -73,8 +73,8 @@ private:
 private:
 	Timer			mTimer;					/**< used to flash messages. */
 
-	Font			mFont;					/**< Internal Font to use. */
-	Font			mBoldFont;				/**< Internal Font to use. */
+	const Font mFont;					/**< Internal Font to use. */
+	const Font mBoldFont;				/**< Internal Font to use. */
 
 	Point<int>		mMapSize;				/**< Rectangle used to position UI elements on screen. */
 	Point<int>		mMouseCoords;			/**< Mouse pointer coordinates. */

--- a/OP2-Landlord/StartState.h
+++ b/OP2-Landlord/StartState.h
@@ -2,6 +2,7 @@
 
 #include "NAS2D/NAS2D.h"
 
+#include "Fonts.h"
 #include "EditorState.h"
 
 // UI
@@ -73,8 +74,8 @@ private:
 private:
 	Timer			mTimer;					/**< used to flash messages. */
 
-	const Font mFont{"fonts/opensans.ttf", 12}; /**< Internal Font to use. */
-	const Font mBoldFont{"fonts/opensans-bold.ttf", 12}; /**< Internal Font to use. */
+	const Font& mFont = fontCache.load("fonts/opensans.ttf", 12); /**< Internal Font to use. */
+	const Font& mBoldFont = fontCache.load("fonts/opensans-bold.ttf", 12); /**< Internal Font to use. */
 
 	Point<int>		mMapSize;				/**< Rectangle used to position UI elements on screen. */
 	Point<int>		mMouseCoords;			/**< Mouse pointer coordinates. */

--- a/OP2-Landlord/StartState.h
+++ b/OP2-Landlord/StartState.h
@@ -73,8 +73,8 @@ private:
 private:
 	Timer			mTimer;					/**< used to flash messages. */
 
-	const Font mFont;					/**< Internal Font to use. */
-	const Font mBoldFont;				/**< Internal Font to use. */
+	const Font mFont{"fonts/opensans.ttf", 12}; /**< Internal Font to use. */
+	const Font mBoldFont{"fonts/opensans-bold.ttf", 12}; /**< Internal Font to use. */
 
 	Point<int>		mMapSize;				/**< Rectangle used to position UI elements on screen. */
 	Point<int>		mMouseCoords;			/**< Mouse pointer coordinates. */

--- a/OP2-Landlord/ToolBar.h
+++ b/OP2-Landlord/ToolBar.h
@@ -80,7 +80,7 @@ private:
 	void btnExit_Clicked();
 
 private:
-	Font			mFont;
+	const Font mFont;
 
 	Image			mToggle;
 

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -25,7 +25,7 @@ Window::~Window()
 }
 
 
-void Window::titleFont(Font& font)
+void Window::titleFont(const Font& font)
 {
 	mBoldFont = &font;
 }

--- a/OP2-Landlord/Window.h
+++ b/OP2-Landlord/Window.h
@@ -13,7 +13,7 @@ public:
 
 	virtual bool responding_to_events() const { return dragging(); }
 
-	void titleFont(Font& font);
+	void titleFont(const Font& font);
 	int titleBarHeight() const;
 
 	virtual void update();
@@ -36,7 +36,7 @@ private:
 	Window& operator=(const Window&) = delete;	/**< Not allowed */
 
 private:
-	Font*		mBoldFont = nullptr;			/**< Font used for window title. */
+	const Font*		mBoldFont = nullptr;			/**< Font used for window title. */
 
 	Point<int>	mMouseCoords;					/**<  */
 


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/pull/760

It seems a bug was introduced in: https://github.com/lairworks/nas2d-core/pull/764
With that PR, having multiple `Font` objects with identical construction parameters, but which don't come from the same cache, can cause instances to fail to render. This is likely caused by one of the `Font` instances going out of scope, and destroying shared resources.

Luckily it's easy to implement `Font` caching with the new `ResourceCache` class. That can be used while the bug is fixed.
