### PR TITLE
Update NAS2D for removal of `argv_0` parameters

### DIFF
--- a/OP2-Landlord/main.cpp
+++ b/OP2-Landlord/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		Filesystem& f = Utility<Filesystem>::init<Filesystem>(argv[0], "OP2-Landlord", "Outpost Universe");
+		Filesystem& f = Utility<Filesystem>::init<Filesystem>("OP2-Landlord", "Outpost Universe");
 		f.mount("data");
 		f.mountReadWrite(f.prefPath());
 


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/pull/1045
