### PR TITLE
Preconstruct `DelegateX` before calling `connect`/`disconnect`

### DIFF
--- a/OP2-Landlord/Button.cpp
+++ b/OP2-Landlord/Button.cpp
@@ -11,18 +11,18 @@ Button::Button():	mState(STATE_NORMAL),
 					mImage(nullptr),
 					mMouseHover(false)
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Button::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Button::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Button::onMouseMotion);
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &Button::onMouseDown});
+	Utility<EventHandler>::get().mouseButtonUp().connect({this, &Button::onMouseUp});
+	Utility<EventHandler>::get().mouseMotion().connect({this, &Button::onMouseMotion});
 	hasFocus(true);
 }
 
 
 Button::~Button()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Button::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Button::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Button::onMouseMotion);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &Button::onMouseDown});
+	Utility<EventHandler>::get().mouseButtonUp().disconnect({this, &Button::onMouseUp});
+	Utility<EventHandler>::get().mouseMotion().disconnect({this, &Button::onMouseMotion});
 
 	if (mImage)
 		delete mImage;

--- a/OP2-Landlord/EditorState.cpp
+++ b/OP2-Landlord/EditorState.cpp
@@ -44,13 +44,13 @@ EditorState::EditorState(const std::string& mapPath, BaseTerrain base, int width
  */
 EditorState::~EditorState()
 {
-	Utility<EventHandler>::get().keyUp().disconnect(this, &EditorState::onKeyUp);
-	Utility<EventHandler>::get().keyDown().disconnect(this, &EditorState::onKeyDown);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &EditorState::onMouseMove);
-	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &EditorState::onMouseUp);
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &EditorState::onMouseDown);
-	Utility<EventHandler>::get().quit().disconnect(this, &EditorState::onQuit);
-	Utility<EventHandler>::get().windowResized().disconnect(this, &EditorState::onWindowResized);
+	Utility<EventHandler>::get().keyUp().disconnect({this, &EditorState::onKeyUp});
+	Utility<EventHandler>::get().keyDown().disconnect({this, &EditorState::onKeyDown});
+	Utility<EventHandler>::get().mouseMotion().disconnect({this, &EditorState::onMouseMove});
+	Utility<EventHandler>::get().mouseButtonUp().disconnect({this, &EditorState::onMouseUp});
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &EditorState::onMouseDown});
+	Utility<EventHandler>::get().quit().disconnect({this, &EditorState::onQuit});
+	Utility<EventHandler>::get().windowResized().disconnect({this, &EditorState::onWindowResized});
 }
 
 
@@ -60,13 +60,13 @@ EditorState::~EditorState()
 void EditorState::initialize()
 {
 	// Hook up event handlers
-	Utility<EventHandler>::get().keyUp().connect(this, &EditorState::onKeyUp);
-	Utility<EventHandler>::get().keyDown().connect(this, &EditorState::onKeyDown);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &EditorState::onMouseMove);
-	Utility<EventHandler>::get().mouseButtonUp().connect(this, &EditorState::onMouseUp);
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &EditorState::onMouseDown);
-	Utility<EventHandler>::get().quit().connect(this, &EditorState::onQuit);
-	Utility<EventHandler>::get().windowResized().connect(this, &EditorState::onWindowResized);
+	Utility<EventHandler>::get().keyUp().connect({this, &EditorState::onKeyUp});
+	Utility<EventHandler>::get().keyDown().connect({this, &EditorState::onKeyDown});
+	Utility<EventHandler>::get().mouseMotion().connect({this, &EditorState::onMouseMove});
+	Utility<EventHandler>::get().mouseButtonUp().connect({this, &EditorState::onMouseUp});
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &EditorState::onMouseDown});
+	Utility<EventHandler>::get().quit().connect({this, &EditorState::onQuit});
+	Utility<EventHandler>::get().windowResized().connect({this, &EditorState::onWindowResized});
 
 	mSelectorRect = {0, 0, TILE_SIZE, TILE_SIZE};
 
@@ -85,7 +85,7 @@ void EditorState::initialize()
 void EditorState::initUi()
 {
 	// ToolBar
-	mToolBar.toolbar_event().connect(this, &EditorState::toolbar_event);
+	mToolBar.toolbar_event().connect({this, &EditorState::toolbar_event});
 
 	mTileGroups.font(mFont);
 	mTileGroups.titleFont(mBoldFont);

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -11,9 +11,9 @@ ListBox::ListBox() :
 	mHighlightBg(Color{0, 255, 0, 80}),
 	mHighlightText(Color::White)
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &ListBox::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &ListBox::onMouseMove);
-	Utility<EventHandler>::get().mouseWheel().connect(this, &ListBox::onMouseWheel);
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &ListBox::onMouseDown});
+	Utility<EventHandler>::get().mouseMotion().connect({this, &ListBox::onMouseMove});
+	Utility<EventHandler>::get().mouseWheel().connect({this, &ListBox::onMouseWheel});
 	
 	init();
 }
@@ -24,11 +24,11 @@ ListBox::ListBox() :
  */
 ListBox::~ListBox()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &ListBox::onMouseDown);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &ListBox::onMouseMove);
-	Utility<EventHandler>::get().mouseWheel().disconnect(this, &ListBox::onMouseWheel);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &ListBox::onMouseDown});
+	Utility<EventHandler>::get().mouseMotion().disconnect({this, &ListBox::onMouseMove});
+	Utility<EventHandler>::get().mouseWheel().disconnect({this, &ListBox::onMouseWheel});
 
-	mSlider.change().disconnect(this, &ListBox::slideChanged);
+	mSlider.change().disconnect({this, &ListBox::slideChanged});
 }
 
 /**
@@ -38,7 +38,7 @@ void ListBox::init()
 {
 	mSlider.length(0);
 	mSlider.thumbPosition(0);
-	mSlider.change().connect(this, &ListBox::slideChanged);
+	mSlider.change().connect({this, &ListBox::slideChanged});
 }
 
 

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -14,13 +14,13 @@
  */
 Slider::Slider() : Control()
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &Slider::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().connect(this, &Slider::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().connect(this, &Slider::onMouseMotion);
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &Slider::onMouseDown});
+	Utility<EventHandler>::get().mouseButtonUp().connect({this, &Slider::onMouseUp});
+	Utility<EventHandler>::get().mouseMotion().connect({this, &Slider::onMouseMotion});
 	hasFocus(true);
 
-	mButton1.press().connect(this, &Slider::button1_Pressed);
-	mButton2.press().connect(this, &Slider::button2_Pressed);
+	mButton1.press().connect({this, &Slider::button1_Pressed});
+	mButton2.press().connect({this, &Slider::button2_Pressed});
 }
 
 
@@ -29,12 +29,12 @@ Slider::Slider() : Control()
  */
 Slider::~Slider()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &Slider::onMouseDown);
-	Utility<EventHandler>::get().mouseButtonUp().disconnect(this, &Slider::onMouseUp);
-	Utility<EventHandler>::get().mouseMotion().disconnect(this, &Slider::onMouseMotion);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &Slider::onMouseDown});
+	Utility<EventHandler>::get().mouseButtonUp().disconnect({this, &Slider::onMouseUp});
+	Utility<EventHandler>::get().mouseMotion().disconnect({this, &Slider::onMouseMotion});
 
-	mButton1.press().disconnect(this, &Slider::button1_Pressed);
-	mButton2.press().disconnect(this, &Slider::button2_Pressed);
+	mButton1.press().disconnect({this, &Slider::button1_Pressed});
+	mButton2.press().disconnect({this, &Slider::button2_Pressed});
 }
 
 

--- a/OP2-Landlord/StartState.cpp
+++ b/OP2-Landlord/StartState.cpp
@@ -43,11 +43,11 @@ StartState::StartState() :
 StartState::~StartState()
 {
 	EventHandler& e = Utility<EventHandler>::get();
-	e.keyDown().disconnect(this, &StartState::onKeyDown);
-	e.mouseMotion().disconnect(this, &StartState::onMouseMove);
-	e.mouseDoubleClick().disconnect(this, &StartState::onDoubleClick);
-	e.windowResized().disconnect(this, &StartState::onWindowResize);
-	e.quit().disconnect(this, &StartState::onQuit);
+	e.keyDown().disconnect({this, &StartState::onKeyDown});
+	e.mouseMotion().disconnect({this, &StartState::onMouseMove});
+	e.mouseDoubleClick().disconnect({this, &StartState::onDoubleClick});
+	e.windowResized().disconnect({this, &StartState::onWindowResize});
+	e.quit().disconnect({this, &StartState::onQuit});
 }
 
 
@@ -70,11 +70,11 @@ void StartState::initialize()
 	// Hook up event handlers
 	EventHandler& e = Utility<EventHandler>::get();
 
-	e.keyDown().connect(this, &StartState::onKeyDown);
-	e.mouseMotion().connect(this, &StartState::onMouseMove);
-	e.mouseDoubleClick().connect(this, &StartState::onDoubleClick);
-	e.windowResized().connect(this, &StartState::onWindowResize);
-	e.quit().connect(this, &StartState::onQuit);
+	e.keyDown().connect({this, &StartState::onKeyDown});
+	e.mouseMotion().connect({this, &StartState::onMouseMove});
+	e.mouseDoubleClick().connect({this, &StartState::onDoubleClick});
+	e.windowResized().connect({this, &StartState::onWindowResize});
+	e.quit().connect({this, &StartState::onQuit});
 }
 
 
@@ -89,13 +89,13 @@ void StartState::initUi()
 	mBtnLoadExisting.font(mBoldFont);
 	mBtnLoadExisting.size(85, 25);
 	mBtnLoadExisting.text("Load Map");
-	mBtnLoadExisting.click().connect(this, &StartState::button_LoadExisting_click);
+	mBtnLoadExisting.click().connect({this, &StartState::button_LoadExisting_click});
 	mBtnLoadExisting.enabled(false);
 
 	mBtnRefreshLists.font(mBoldFont);
 	mBtnRefreshLists.size(100, 25);
 	mBtnRefreshLists.text("Refresh List");
-	mBtnRefreshLists.click().connect(this, &StartState::button_RefreshLists_click);
+	mBtnRefreshLists.click().connect({this, &StartState::button_RefreshLists_click});
 
 	mMapFilesMenu.font(mBoldFont);
 
@@ -109,21 +109,21 @@ void StartState::initUi()
 	mBtn64x64.type(Button::BUTTON_TOGGLE);
 	mBtn64x64.size(100, 20);
 	mBtn64x64.toggle(true);
-	mBtn64x64.click().connect(this, &StartState::btn64x64_Clicked);
+	mBtn64x64.click().connect({this, &StartState::btn64x64_Clicked});
 
 	mBtn64x128.font(mBoldFont);
 	mBtn64x128.text("64x128");
 	mBtn64x128.type(Button::BUTTON_TOGGLE);
 	mBtn64x128.size(100, 20);
 	mBtn64x128.toggle(false);
-	mBtn64x128.click().connect(this, &StartState::btn64x128_Clicked);
+	mBtn64x128.click().connect({this, &StartState::btn64x128_Clicked});
 
 	mBtn64x256.font(mBoldFont);
 	mBtn64x256.text("64x256");
 	mBtn64x256.type(Button::BUTTON_TOGGLE);
 	mBtn64x256.size(100, 20);
 	mBtn64x256.toggle(false);
-	mBtn64x256.click().connect(this, &StartState::btn64x256_Clicked);
+	mBtn64x256.click().connect({this, &StartState::btn64x256_Clicked});
 
 
 	// Second Row
@@ -132,21 +132,21 @@ void StartState::initUi()
 	mBtn128x128.type(Button::BUTTON_TOGGLE);
 	mBtn128x128.size(100, 20);
 	mBtn128x128.toggle(false);
-	mBtn128x128.click().connect(this, &StartState::btn128x128_Clicked);
+	mBtn128x128.click().connect({this, &StartState::btn128x128_Clicked});
 
 	mBtn128x64.font(mBoldFont);
 	mBtn128x64.text("128x64");
 	mBtn128x64.type(Button::BUTTON_TOGGLE);
 	mBtn128x64.size(100, 20);
 	mBtn128x64.toggle(false);
-	mBtn128x64.click().connect(this, &StartState::btn128x64_Clicked);
+	mBtn128x64.click().connect({this, &StartState::btn128x64_Clicked});
 
 	mBtn128x256.font(mBoldFont);
 	mBtn128x256.text("128x256");
 	mBtn128x256.type(Button::BUTTON_TOGGLE);
 	mBtn128x256.size(100, 20);
 	mBtn128x256.toggle(false);
-	mBtn128x256.click().connect(this, &StartState::btn128x256_Clicked);
+	mBtn128x256.click().connect({this, &StartState::btn128x256_Clicked});
 
 	/// Third Row
 	mBtn256x256.font(mBoldFont);
@@ -154,45 +154,45 @@ void StartState::initUi()
 	mBtn256x256.type(Button::BUTTON_TOGGLE);
 	mBtn256x256.size(100, 20);
 	mBtn256x256.toggle(false);
-	mBtn256x256.click().connect(this, &StartState::btn256x256_Clicked);
+	mBtn256x256.click().connect({this, &StartState::btn256x256_Clicked});
 
 	mBtn256x128.font(mBoldFont);
 	mBtn256x128.text("256x128");
 	mBtn256x128.type(Button::BUTTON_TOGGLE);
 	mBtn256x128.size(100, 20);
 	mBtn256x128.toggle(false);
-	mBtn256x128.click().connect(this, &StartState::btn256x128_Clicked);
+	mBtn256x128.click().connect({this, &StartState::btn256x128_Clicked});
 
 	mBtn512x256.font(mBoldFont);
 	mBtn512x256.text("512x256");
 	mBtn512x256.type(Button::BUTTON_TOGGLE);
 	mBtn512x256.size(100, 20);
 	mBtn512x256.toggle(false);
-	mBtn512x256.click().connect(this, &StartState::btn512x256_Clicked);
+	mBtn512x256.click().connect({this, &StartState::btn512x256_Clicked});
 
 	mBtnCreateNew.font(mBoldFont);
 	mBtnCreateNew.size(85, 25);
 	mBtnCreateNew.text("Create New");
-	mBtnCreateNew.click().connect(this, &StartState::button_CreateNew_click);
+	mBtnCreateNew.click().connect({this, &StartState::button_CreateNew_click});
 
 	// TERRAIN TYPES
 	mBtnMud.image("sys/mud.png");
 	mBtnMud.size(135);
 	mBtnMud.type(Button::BUTTON_TOGGLE);
 	mBtnMud.toggle(true);
-	mBtnMud.click().connect(this, &StartState::btnMud_Clicked);
+	mBtnMud.click().connect({this, &StartState::btnMud_Clicked});
 
 	mBtnRock.image("sys/rock.png");
 	mBtnRock.size(135);
 	mBtnRock.type(Button::BUTTON_TOGGLE);
 	mBtnRock.toggle(false);
-	mBtnRock.click().connect(this, &StartState::btnRock_Clicked);
+	mBtnRock.click().connect({this, &StartState::btnRock_Clicked});
 
 	mBtnSand.image("sys/sand.png");
 	mBtnSand.size(135);
 	mBtnSand.type(Button::BUTTON_TOGGLE);
 	mBtnSand.toggle(false);
-	mBtnSand.click().connect(this, &StartState::btnSand_Clicked);
+	mBtnSand.click().connect({this, &StartState::btnSand_Clicked});
 
 	txtMapPath.font(mBoldFont);
 	txtMapPath.text("");

--- a/OP2-Landlord/TextField.cpp
+++ b/OP2-Landlord/TextField.cpp
@@ -25,9 +25,9 @@ TextField::TextField():	mCursorPosition(0),
 						mShowCursor(false),
 						mNumbersOnly(false)
 {
-	Utility<EventHandler>::get().mouseButtonDown().connect(this, &TextField::onMouseDown);
-	Utility<EventHandler>::get().keyDown().connect(this, &TextField::onKeyDown);
-	Utility<EventHandler>::get().textInput().connect(this, &TextField::onTextInput);
+	Utility<EventHandler>::get().mouseButtonDown().connect({this, &TextField::onMouseDown});
+	Utility<EventHandler>::get().keyDown().connect({this, &TextField::onKeyDown});
+	Utility<EventHandler>::get().textInput().connect({this, &TextField::onTextInput});
 	hasFocus(false);
 	Utility<EventHandler>::get().textInputMode(true);
 }
@@ -35,9 +35,9 @@ TextField::TextField():	mCursorPosition(0),
 
 TextField::~TextField()
 {
-	Utility<EventHandler>::get().mouseButtonDown().disconnect(this, &TextField::onMouseDown);
-	Utility<EventHandler>::get().keyDown().disconnect(this, &TextField::onKeyDown);
-	Utility<EventHandler>::get().textInput().disconnect(this, &TextField::onTextInput);
+	Utility<EventHandler>::get().mouseButtonDown().disconnect({this, &TextField::onMouseDown});
+	Utility<EventHandler>::get().keyDown().disconnect({this, &TextField::onKeyDown});
+	Utility<EventHandler>::get().textInput().disconnect({this, &TextField::onTextInput});
 }
 
 void TextField::resetCursorPosition()

--- a/OP2-Landlord/TileGroups.cpp
+++ b/OP2-Landlord/TileGroups.cpp
@@ -17,19 +17,19 @@ TileGroups::TileGroups()
  */
 TileGroups::~TileGroups()
 {
-	mSlider.change().disconnect(this, &TileGroups::mSlider_Changed);
-	Utility<EventHandler>::get().keyDown().disconnect(this, &TileGroups::onKeyDown);
-	Utility<EventHandler>::get().mouseWheel().disconnect(this, &TileGroups::mouseWheel);
+	mSlider.change().disconnect({this, &TileGroups::mSlider_Changed});
+	Utility<EventHandler>::get().keyDown().disconnect({this, &TileGroups::onKeyDown});
+	Utility<EventHandler>::get().mouseWheel().disconnect({this, &TileGroups::mouseWheel});
 }
 
 
 void TileGroups::_init()
 {
 	text("Tile Groups");
-	mSlider.change().connect(this, &TileGroups::mSlider_Changed);
+	mSlider.change().connect({this, &TileGroups::mSlider_Changed});
 
-	Utility<EventHandler>::get().keyDown().connect(this, &TileGroups::onKeyDown);
-	Utility<EventHandler>::get().mouseWheel().connect(this, &TileGroups::mouseWheel);
+	Utility<EventHandler>::get().keyDown().connect({this, &TileGroups::onKeyDown});
+	Utility<EventHandler>::get().mouseWheel().connect({this, &TileGroups::mouseWheel});
 }
 
 

--- a/OP2-Landlord/ToolBar.cpp
+++ b/OP2-Landlord/ToolBar.cpp
@@ -18,9 +18,9 @@ ToolBar::~ToolBar()
 {
 	EventHandler& e = Utility<EventHandler>::get();
 
-	e.keyDown().disconnect(this, &ToolBar::onKeyDown);
-	e.mouseWheel().disconnect(this, &ToolBar::onMouseWheel);
-	e.windowResized().disconnect(this, &ToolBar::onWindowResized);
+	e.keyDown().disconnect({this, &ToolBar::onKeyDown});
+	e.mouseWheel().disconnect({this, &ToolBar::onMouseWheel});
+	e.windowResized().disconnect({this, &ToolBar::onWindowResized});
 
 	mToolbarEvent.clear();
 }
@@ -32,7 +32,7 @@ void ToolBar::initUi()
 	btnSave.image("sys/save.png");
 	btnSave.size(22, 28);
 	btnSave.position(2, 2);
-	btnSave.click().connect(this, &ToolBar::btnSave_Clicked);
+	btnSave.click().connect({this, &ToolBar::btnSave_Clicked});
 
 	// EDIT TOOLS
 	btnPencil.image("sys/pencil.png");
@@ -40,13 +40,13 @@ void ToolBar::initUi()
 	btnPencil.toggle(true);
 	btnPencil.size(22, 28);
 	btnPencil.position(btnSave.positionX() + btnSave.width() + 18 + BUTTON_SPACE, 2);
-	btnPencil.click().connect(this, &ToolBar::btnPencil_Clicked);
+	btnPencil.click().connect({this, &ToolBar::btnPencil_Clicked});
 
 	btnFill.image("sys/paintcan.png");
 	btnFill.type(Button::BUTTON_TOGGLE);
 	btnFill.size(22, 28);
 	btnFill.position(btnPencil.positionX() + btnPencil.width() + BUTTON_SPACE, 2);
-	btnFill.click().connect(this, &ToolBar::btnFill_Clicked);
+	btnFill.click().connect({this, &ToolBar::btnFill_Clicked});
 
 	btnFillContiguous.type(Button::BUTTON_TOGGLE);
 	btnFillContiguous.toggle(true);
@@ -60,18 +60,18 @@ void ToolBar::initUi()
 	btnErase.type(Button::BUTTON_TOGGLE);
 	btnErase.size(22, 28);
 	btnErase.position(btnFill.positionX() + btnFill.width() + BUTTON_SPACE, 2);
-	btnErase.click().connect(this, &ToolBar::btnErase_Clicked);
+	btnErase.click().connect({this, &ToolBar::btnErase_Clicked});
 
 	// Spinner buttons
 	btnSpinnerUp.image("sys/up.png");
 	btnSpinnerUp.size(22, 14);
 	btnSpinnerUp.position(btnErase.positionX() + btnErase.width() + BUTTON_SPACE + 21, 2);
-	btnSpinnerUp.click().connect(this, &ToolBar::btnSpinnerUp_Clicked);
+	btnSpinnerUp.click().connect({this, &ToolBar::btnSpinnerUp_Clicked});
 
 	btnSpinnerDown.image("sys/down.png");
 	btnSpinnerDown.size(22, 13);
 	btnSpinnerDown.position(btnErase.positionX() + btnErase.width() + BUTTON_SPACE + 21, 17);
-	btnSpinnerDown.click().connect(this, &ToolBar::btnSpinnerDown_Clicked);
+	btnSpinnerDown.click().connect({this, &ToolBar::btnSpinnerDown_Clicked});
 
 
 	// LAYER EDIT
@@ -85,7 +85,7 @@ void ToolBar::initUi()
 	btnExit.image("sys/exit.png");
 	btnExit.size(22, 28);
 	btnExit.position(Utility<Renderer>::get().size().x - 24, 2);
-	btnExit.click().connect(this, &ToolBar::btnExit_Clicked);
+	btnExit.click().connect({this, &ToolBar::btnExit_Clicked});
 
 
 	btnTileGroupsToggle.image("sys/group.png");
@@ -93,21 +93,21 @@ void ToolBar::initUi()
 	btnTileGroupsToggle.toggle(false);
 	btnTileGroupsToggle.size(22, 28);
 	btnTileGroupsToggle.position(btnExit.positionX() - 42, 2);
-	btnTileGroupsToggle.click().connect(this, &ToolBar::btnTileGroupsToggle_Clicked);
+	btnTileGroupsToggle.click().connect({this, &ToolBar::btnTileGroupsToggle_Clicked});
 
 	btnTilePaletteToggle.image("sys/palette.png");
 	btnTilePaletteToggle.type(Button::BUTTON_TOGGLE);
 	btnTilePaletteToggle.toggle(false);
 	btnTilePaletteToggle.size(22, 28);
 	btnTilePaletteToggle.position(btnTileGroupsToggle.positionX() - 24, 2);
-	btnTilePaletteToggle.click().connect(this, &ToolBar::btnTilePaletteToggle_Clicked);
+	btnTilePaletteToggle.click().connect({this, &ToolBar::btnTilePaletteToggle_Clicked});
 
 	btnMiniMapToggle.image("sys/map.png");
 	btnMiniMapToggle.type(Button::BUTTON_TOGGLE);
 	btnMiniMapToggle.toggle(false);
 	btnMiniMapToggle.size(22, 28);
 	btnMiniMapToggle.position(btnTilePaletteToggle.positionX() - 24, 2);
-	btnMiniMapToggle.click().connect(this, &ToolBar::btnMiniMapToggle_Clicked);
+	btnMiniMapToggle.click().connect({this, &ToolBar::btnMiniMapToggle_Clicked});
 
 	hookEvents();
 }
@@ -123,9 +123,9 @@ void ToolBar::hookEvents()
 {
 	EventHandler& e = Utility<EventHandler>::get();
 
-	e.keyDown().connect(this, &ToolBar::onKeyDown);
-	e.mouseWheel().connect(this, &ToolBar::onMouseWheel);
-	e.windowResized().connect(this, &ToolBar::onWindowResized);
+	e.keyDown().connect({this, &ToolBar::onKeyDown});
+	e.mouseWheel().connect({this, &ToolBar::onMouseWheel});
+	e.windowResized().connect({this, &ToolBar::onWindowResized});
 }
 
 

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -10,18 +10,18 @@ const int TITLE_BAR_HEIGHT = 20;
 Window::Window()
 {
 	EventHandler& e = Utility<EventHandler>::get();
-	e.mouseButtonDown().connect(this, &Window::onMouseDown);
-	e.mouseButtonUp().connect(this, &Window::onMouseUp);
-	e.mouseMotion().connect(this, &Window::onMouseMotion);
+	e.mouseButtonDown().connect({this, &Window::onMouseDown});
+	e.mouseButtonUp().connect({this, &Window::onMouseUp});
+	e.mouseMotion().connect({this, &Window::onMouseMotion});
 }
 
 
 Window::~Window()
 {
 	EventHandler& e = Utility<EventHandler>::get();
-	e.mouseButtonDown().disconnect(this, &Window::onMouseDown);
-	e.mouseButtonUp().disconnect(this, &Window::onMouseUp);
-	e.mouseMotion().disconnect(this, &Window::onMouseMotion);
+	e.mouseButtonDown().disconnect({this, &Window::onMouseDown});
+	e.mouseButtonUp().disconnect({this, &Window::onMouseUp});
+	e.mouseMotion().disconnect({this, &Window::onMouseMotion});
 }
 
 


### PR DESCRIPTION
This means fewer overloaded methods will be needed on the `SignalSource` object. It also more tightly associates `this` pointers with member function pointers by composing them into an obvious compound object.

One reason to want to reduce `connect` overloads, is to add debugging capabilities to the `connect` method. This is easier when only a single overload needs to be updated.

Reference: https://github.com/OutpostUniverse/OPHD/pull/1271
