### PR TITLE
Remove `using namespace` from headers

### DIFF
--- a/OP2-Landlord/Button.h
+++ b/OP2-Landlord/Button.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-using namespace NAS2D;
 
 class Button: public Control
 {
@@ -59,7 +58,7 @@ private:
 	ClickCallback	mCallback;			/**< Signal when the Button is activated. */
 	PressCallback	mPressed;			/**< Signal when the Button is pressed (as in click and hold). */
 
-	Image*			mImage;
+	NAS2D::Image*			mImage;
 
 	bool			mMouseHover;		/**< Mouse is within the bounds of the Button. */
 };

--- a/OP2-Landlord/Common.cpp
+++ b/OP2-Landlord/Common.cpp
@@ -14,33 +14,33 @@ void flipBool(bool& b)
 /**
  * Draws a beveled box.
  */
-void bevelBox(int x, int y, int w, int h, bool sunk, const Color& bgcolor)
+void bevelBox(int x, int y, int w, int h, bool sunk, const NAS2D::Color& bgcolor)
 {
-	Renderer& r = Utility<Renderer>::get();
+	auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	r.drawBoxFilled(NAS2D::Rectangle{x, y, w, h}, bgcolor);
 
 	if (!sunk)
 	{
-		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{x + w, y}, Color::White);
-		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{x, y + h}, Color::White);
+		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{x + w, y}, NAS2D::Color::White);
+		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{x, y + h}, NAS2D::Color::White);
 
-		r.drawLine(NAS2D::Point{x - 1, y + h - 1}, NAS2D::Point{x + w, y + h - 1}, Color::Gray);
-		r.drawLine(NAS2D::Point{x + w - 1, y + 1}, NAS2D::Point{x + w - 1, y + h - 1}, Color::Gray);
+		r.drawLine(NAS2D::Point{x - 1, y + h - 1}, NAS2D::Point{x + w, y + h - 1}, NAS2D::Color::Gray);
+		r.drawLine(NAS2D::Point{x + w - 1, y + 1}, NAS2D::Point{x + w - 1, y + h - 1}, NAS2D::Color::Gray);
 
-		r.drawLine(NAS2D::Point{x - 0.5f, static_cast<float>(y + h)}, NAS2D::Point{x + w, y + h}, Color::Black);
-		r.drawLine(NAS2D::Point{x + w, y}, NAS2D::Point{x + w, y + h}, Color::Black);
+		r.drawLine(NAS2D::Point{x - 0.5f, static_cast<float>(y + h)}, NAS2D::Point{x + w, y + h}, NAS2D::Color::Black);
+		r.drawLine(NAS2D::Point{x + w, y}, NAS2D::Point{x + w, y + h}, NAS2D::Color::Black);
 	}
 	else
 	{
-		r.drawLine(NAS2D::Point{x, y + h}, NAS2D::Point{x + w, y + h}, Color::White);
-		r.drawLine(NAS2D::Point{x + w, y}, NAS2D::Point{x + w, y + h}, Color::White);
+		r.drawLine(NAS2D::Point{x, y + h}, NAS2D::Point{x + w, y + h}, NAS2D::Color::White);
+		r.drawLine(NAS2D::Point{x + w, y}, NAS2D::Point{x + w, y + h}, NAS2D::Color::White);
 		
-		r.drawLine(NAS2D::Point{x + 1, y + 1}, NAS2D::Point{x + w, y + 1}, Color::Gray);
-		r.drawLine(NAS2D::Point{x + 1, y + 1}, NAS2D::Point{x + 1, y + h}, Color::Gray);
+		r.drawLine(NAS2D::Point{x + 1, y + 1}, NAS2D::Point{x + w, y + 1}, NAS2D::Color::Gray);
+		r.drawLine(NAS2D::Point{x + 1, y + 1}, NAS2D::Point{x + 1, y + h}, NAS2D::Color::Gray);
 
-		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{x + w, y}, Color::Black);
-		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{static_cast<float>(x), y + h + 0.5f}, Color::Black);
+		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{x + w, y}, NAS2D::Color::Black);
+		r.drawLine(NAS2D::Point{x, y}, NAS2D::Point{static_cast<float>(x), y + h + 0.5f}, NAS2D::Color::Black);
 	}
 }
 
@@ -120,7 +120,7 @@ int gridLocation(int point, int cameraPoint, int viewportDimension)
 /**
  * Convenience function to pass a Rectangle<float> to \c isPointInRect()
  */
-bool pointInRect_f(int x, int y, const Rectangle<float>& rect)
+bool pointInRect_f(int x, int y, const NAS2D::Rectangle<float>& rect)
 {
 	return rect.to<int>().contains(NAS2D::Point{x, y});
 }

--- a/OP2-Landlord/Common.h
+++ b/OP2-Landlord/Common.h
@@ -4,12 +4,12 @@
 
 #include <NAS2D/NAS2D.h>
 
-using namespace NAS2D;
+#include <SDL2/SDL.h>
 
 #include <string>
 #include <memory>
 
-#include <SDL2/SDL.h>
+
 // ===========================================================================
 // = ENUMERATIONS
 // ===========================================================================
@@ -47,7 +47,7 @@ const int NO_SELECTION		= -1;	/**< Indicates no selection. */
 // ===========================================================================
 void flipBool(bool& b);
 
-void bevelBox(int x, int y, int w, int h, bool sunk = false, const Color& bgcolor = Color{180, 180, 180});
+void bevelBox(int x, int y, int w, int h, bool sunk = false, const NAS2D::Color& bgcolor = NAS2D::Color{180, 180, 180});
 
 std::string TrimString(const std::string& src, const std::string& c = " \r\n");
 

--- a/OP2-Landlord/Control.h
+++ b/OP2-Landlord/Control.h
@@ -2,8 +2,6 @@
 
 #include "NAS2D/NAS2D.h"
 
-using namespace NAS2D;
-
 
 /**
  * \class Control

--- a/OP2-Landlord/Control.h
+++ b/OP2-Landlord/Control.h
@@ -29,9 +29,9 @@ public:
 	Control();
 	virtual ~Control();
 
-	void font(const Font& font);
+	void font(const NAS2D::Font& font);
 
-	void position(const Point<float>& pos);
+	void position(const NAS2D::Point<float>& pos);
 	void position(float x, float y);
 
 	float positionX();
@@ -51,7 +51,7 @@ public:
 	virtual void hide() { visible(false); }
 	virtual void show() { visible(true); }
 
-	const Rectangle<float>& rect() const;
+	const NAS2D::Rectangle<float>& rect() const;
 
 	virtual void hasFocus(bool focus);
 	bool hasFocus() const;
@@ -98,10 +98,10 @@ protected:
 	virtual void onTextChanged() { mTextChanged(this); };
 	virtual void onFontChanged() {};
 
-	const Font& font();
+	const NAS2D::Font& font();
 	bool fontSet() const;
 
-	Rectangle<float>& _rect();
+	NAS2D::Rectangle<float>& _rect();
 	std::string& _text();
 
 protected:
@@ -115,11 +115,11 @@ private:
 
 	virtual void draw() {};
 
-	const Font*			mFont;			/**< Pointer to a Font object. Control DOES NOT own the pointer. */
+	const NAS2D::Font*			mFont;			/**< Pointer to a Font object. Control DOES NOT own the pointer. */
 
 	std::string		mText;			/**< Internal text string. */
 
-	Rectangle<float>	mRect;			/**< Area of the Control. */
+	NAS2D::Rectangle<float>	mRect;			/**< Area of the Control. */
 
 	bool			mEnabled;		/**< Flag indicating whether or not the Control is enabled. */
 	bool			mHasFocus;		/**< Flag indicating that the Control has input focus. */

--- a/OP2-Landlord/EditorState.h
+++ b/OP2-Landlord/EditorState.h
@@ -50,7 +50,7 @@ private:
 	void changeTileTexture();
 	void pattern(int value = 0);
 	void patternFill();
-	void patternFill_Contig(const Point<int>& _pt, int seed_index);
+	void patternFill_Contig(const NAS2D::Point<int>& _pt, int seed_index);
 
 	void pattern_collision();
 	void handleLeftButtonDown(int x, int y);
@@ -61,21 +61,21 @@ private:
 	void toolbar_event(ToolBar::ToolBarAction _act);
 
 private:
-	Timer			mTimer;
-	const Font& mFont = fontCache.load("fonts/opensans.ttf", 12);
-	const Font& mBoldFont = fontCache.load("fonts/opensans-bold.ttf", 12);
+	NAS2D::Timer			mTimer;
+	const NAS2D::Font& mFont = fontCache.load("fonts/opensans.ttf", 12);
+	const NAS2D::Font& mBoldFont = fontCache.load("fonts/opensans-bold.ttf", 12);
 
 	MapFile*		mMap = nullptr;				/**< Map object. */
 
 	std::string		mMapSavePath;				/**< Filename to use for loading/saving. */
 
 	// PRIMITIVES
-	Point<int>		mMouseCoords;
-	Point<int>		mSavedMouseCoords;
-	Point<int>		mTileHighlight;
+	NAS2D::Point<int>		mMouseCoords;
+	NAS2D::Point<int>		mSavedMouseCoords;
+	NAS2D::Point<int>		mTileHighlight;
 
-	Rectangle<int>	mSelectorRect;
-	Rectangle<int>	mCellInspectRect;
+	NAS2D::Rectangle<int>	mSelectorRect;
+	NAS2D::Rectangle<int>	mCellInspectRect;
 
 	// UI ELEMENTS
 	TileGroups		mTileGroups;
@@ -88,5 +88,5 @@ private:
 	bool			mRightButtonDown = false;	/**< Flag for right mouse button down. */
 	bool			mMapChanged = false;		/**< Used to determine if the map changed. */
 
-	State*			mReturnState = this;		/**< Return state (nullptr terminates the program). */
+	NAS2D::State*			mReturnState = this;		/**< Return state (nullptr terminates the program). */
 };

--- a/OP2-Landlord/EditorState.h
+++ b/OP2-Landlord/EditorState.h
@@ -14,7 +14,7 @@
 #include <map>
 
 
-class EditorState: public State
+class EditorState : public NAS2D::State
 {
 public:
 	EditorState(const std::string& mapPath);

--- a/OP2-Landlord/EditorState.h
+++ b/OP2-Landlord/EditorState.h
@@ -13,8 +13,6 @@
 #include <string>
 #include <map>
 
-using namespace NAS2D;
-
 
 class EditorState: public State
 {

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -3,6 +3,9 @@
 #include "Common.h"
 
 
+using namespace NAS2D;
+
+
 /**
  * C'tor
  */

--- a/OP2-Landlord/ListBox.h
+++ b/OP2-Landlord/ListBox.h
@@ -69,7 +69,7 @@ private:
 	int							mItemMax = 0;
 	int							mItemWidth = 0;
 
-	StringList					mItems;				/**< List of items preserved in the order in which they're added. */
+	NAS2D::StringList					mItems;				/**< List of items preserved in the order in which they're added. */
 
 	NAS2D::Color					mText;				/**< Text Color */
 	NAS2D::Color					mHighlightBg;		/**< Highlight Background color. */

--- a/OP2-Landlord/ListBox.h
+++ b/OP2-Landlord/ListBox.h
@@ -25,8 +25,8 @@ public:
 
 	void sort() { std::sort(mItems.begin(), mItems.end()); }
 
-	void textColor(const Color& color)	{ mText = color; }
-	void selectColor(const Color& color)	{ mHighlightBg = color; }
+	void textColor(const NAS2D::Color& color)	{ mText = color; }
+	void selectColor(const NAS2D::Color& color)	{ mHighlightBg = color; }
 
 	void addItem(const std::string& item);
 	void removeItem(const std::string& item);
@@ -46,7 +46,7 @@ public:
 	SelectionChangedCallback& selectionChanged() { return mSelectionChanged; }
 
 protected:
-	virtual void onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position) final;
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) final;
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> change) final;
 	void onMouseWheel(NAS2D::Vector<int> change);
 	void slideChanged(double _position);
@@ -71,11 +71,11 @@ private:
 
 	StringList					mItems;				/**< List of items preserved in the order in which they're added. */
 
-	Color					mText;				/**< Text Color */
-	Color					mHighlightBg;		/**< Highlight Background color. */
-	Color					mHighlightText;		/**< Text Color for an item that is currently highlighted. */
+	NAS2D::Color					mText;				/**< Text Color */
+	NAS2D::Color					mHighlightBg;		/**< Highlight Background color. */
+	NAS2D::Color					mHighlightText;		/**< Text Color for an item that is currently highlighted. */
 
-	Point<int>					mMouseCoords;		/**< Mouse position. */
+	NAS2D::Point<int>					mMouseCoords;		/**< Mouse position. */
 
 	SelectionChangedCallback	mSelectionChanged;	/**< Callback for selection changed callback. */
 	Slider						mSlider;			/**<  */

--- a/OP2-Landlord/MiniMap.h
+++ b/OP2-Landlord/MiniMap.h
@@ -7,9 +7,6 @@
 #include "NAS2D/NAS2D.h"
 
 
-using namespace NAS2D;
-
-
 class MiniMap : public Window
 {
 public:
@@ -37,9 +34,9 @@ private:
 	void adjustCamera(int x, int y);
 
 private:
-	Rectangle<int>	mViewRect;
+	NAS2D::Rectangle<int>	mViewRect;
 
-	Image*			mMiniMap = nullptr;
+	NAS2D::Image*			mMiniMap = nullptr;
 
 	MapFile*		mMap = nullptr;
 

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -5,8 +5,9 @@
  */
 #include "Slider.h"
 
-
 #include <algorithm>
+
+using namespace NAS2D;
 
 
 /**

--- a/OP2-Landlord/Slider.h
+++ b/OP2-Landlord/Slider.h
@@ -46,8 +46,8 @@ public:
 	ValueChangedCallback& change() { return mCallback; } 	/*!< Give the callback to enable another control or a window to dis/connect to this event call. */
 
 protected:
-	virtual void onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position); 	/*!< Event raised on mouse button down. */
-	virtual void onMouseUp(EventHandler::MouseButton button, NAS2D::Point<int> position); 	/*!< Event raised on mouse button up. */
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position); 	/*!< Event raised on mouse button down. */
+	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position); 	/*!< Event raised on mouse button up. */
 	virtual void onMouseMotion(NAS2D::Point<int> position, NAS2D::Vector<int> change); 	/*!< Event raised on mouse move. */
 
 private:
@@ -77,7 +77,7 @@ private:
 	void button2_Pressed(bool pressed);
 
 private:
-	Timer					mTimer;
+	NAS2D::Timer					mTimer;
 
 	ValueChangedCallback	mCallback;					/*!< Callback executed when the value is changed. */
 
@@ -107,6 +107,6 @@ private:
 	Button					mButton1;
 	Button					mButton2;
 
-	Rectangle<float>			mSlideBar;					/*!< Area on screen where the slide area is displayed. */
-	Rectangle<float>			mSlider;					/*!< Area on screen where the slider is displayed. */
+	NAS2D::Rectangle<float>			mSlideBar;					/*!< Area on screen where the slide area is displayed. */
+	NAS2D::Rectangle<float>			mSlider;					/*!< Area on screen where the slider is displayed. */
 };

--- a/OP2-Landlord/StartState.h
+++ b/OP2-Landlord/StartState.h
@@ -16,7 +16,7 @@
  * \class StartState
  * \brief Implements a startup state for the CoM Map Editor.
  */
-class StartState: public State
+class StartState : public NAS2D::State
 {
 public:
 
@@ -27,7 +27,7 @@ protected:
 
 	void initialize();
 
-	State* update();
+	NAS2D::State* update();
 
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> change);
@@ -37,7 +37,7 @@ protected:
 	void onQuit();
 
 private:
-	StringList getFileList(const std::string& directory);
+	NAS2D::StringList getFileList(const std::string& directory);
 		
 	void fillMapMenu();
 	

--- a/OP2-Landlord/StartState.h
+++ b/OP2-Landlord/StartState.h
@@ -12,9 +12,6 @@
 #include "TextField.h"
 
 
-using namespace NAS2D;
-
-
 /**
  * \class StartState
  * \brief Implements a startup state for the CoM Map Editor.
@@ -34,7 +31,7 @@ protected:
 
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> change);
-	void onDoubleClick(EventHandler::MouseButton button, NAS2D::Point<int> position);
+	void onDoubleClick(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
 	void onWindowResize(NAS2D::Vector<int> newSize);
 
 	void onQuit();
@@ -72,15 +69,15 @@ private:
 	void btnSand_Clicked();
 
 private:
-	Timer			mTimer;					/**< used to flash messages. */
+	NAS2D::Timer			mTimer;					/**< used to flash messages. */
 
-	const Font& mFont = fontCache.load("fonts/opensans.ttf", 12); /**< Internal Font to use. */
-	const Font& mBoldFont = fontCache.load("fonts/opensans-bold.ttf", 12); /**< Internal Font to use. */
+	const NAS2D::Font& mFont = fontCache.load("fonts/opensans.ttf", 12); /**< Internal Font to use. */
+	const NAS2D::Font& mBoldFont = fontCache.load("fonts/opensans-bold.ttf", 12); /**< Internal Font to use. */
 
-	Point<int>		mMapSize;				/**< Rectangle used to position UI elements on screen. */
-	Point<int>		mMouseCoords;			/**< Mouse pointer coordinates. */
+	NAS2D::Point<int>		mMapSize;				/**< Rectangle used to position UI elements on screen. */
+	NAS2D::Point<int>		mMouseCoords;			/**< Mouse pointer coordinates. */
 
-	Rectangle<int>	mLayoutRect;			/**< Rectangle used to position UI elements on screen. */
+	NAS2D::Rectangle<int>	mLayoutRect;			/**< Rectangle used to position UI elements on screen. */
 
 	Button			mBtnCreateNew;			/**< Create New button. */
 	Button			mBtnLoadExisting;		/**< Load Existing button. */
@@ -111,5 +108,5 @@ private:
 
 	bool			mScanningMaps = true;	/**<  */
 
-	State*			mReturnState = this;	/**< State to return during updates. */
+	NAS2D::State*			mReturnState = this;	/**< State to return during updates. */
 };

--- a/OP2-Landlord/TextArea.cpp
+++ b/OP2-Landlord/TextArea.cpp
@@ -2,6 +2,10 @@
 
 #include <vector>
 
+
+using namespace NAS2D;
+
+
 TextArea::TextArea() : mNumLines(0)
 {}
 

--- a/OP2-Landlord/TextArea.h
+++ b/OP2-Landlord/TextArea.h
@@ -6,7 +6,6 @@
 
 #include <string>
 
-using namespace NAS2D;
 
 class TextArea : public Control
 {

--- a/OP2-Landlord/TextField.cpp
+++ b/OP2-Landlord/TextField.cpp
@@ -10,6 +10,9 @@
 #include <locale>
 
 
+using namespace NAS2D;
+
+
 const int FIELD_PADDING = 4;
 
 const int CURSOR_BLINK_DELAY = 250;

--- a/OP2-Landlord/TextField.h
+++ b/OP2-Landlord/TextField.h
@@ -10,7 +10,6 @@
 #include "NAS2D/NAS2D.h"
 #include "Control.h"
 
-using namespace NAS2D;
 
 /**
  * \class TextField
@@ -53,8 +52,8 @@ public:
 	void update();
 
 protected:
-	virtual void onMouseDown(EventHandler::MouseButton button, NAS2D::Point<int> position);
-	virtual void onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat);
+	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position);
+	virtual void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);
 	void onTextInput(const std::string&);
 
 private:
@@ -70,7 +69,7 @@ private:
 	void draw();
 
 private:
-	Timer				mCursorTimer;		/**< Timer for the cursor blink. */
+	NAS2D::Timer				mCursorTimer;		/**< Timer for the cursor blink. */
 
 	int 				mCursorPosition;	/**< Position of the Insertion Cursor. */
 	int 				mCursorX;			/**< Pixel position of the Cursor. */

--- a/OP2-Landlord/TileGroups.h
+++ b/OP2-Landlord/TileGroups.h
@@ -10,7 +10,6 @@
 #include "Map/MapFile.h"
 #include "Map/TileGroup.h"
 
-using namespace NAS2D;
 
 /**
  * \class TileGroups

--- a/OP2-Landlord/TilePalette.cpp
+++ b/OP2-Landlord/TilePalette.cpp
@@ -3,10 +3,11 @@
 #include "Common.h"
 
 
+using namespace NAS2D;
+
+
 const auto PALETTE_DIMENSIONS = Vector{196, 300};
 
-
-using namespace NAS2D;
 
 /**
  * C'Tor

--- a/OP2-Landlord/TilePalette.h
+++ b/OP2-Landlord/TilePalette.h
@@ -6,7 +6,6 @@
 #include "Pattern.h"
 #include "Window.h"
 
-using namespace NAS2D;
 
 /**
  * \class TilePalette
@@ -37,8 +36,8 @@ private:
 	void mouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> change);
 
 private:
-	Point<int>		mStartIndex;				/**< Index of the selected tile(s). */
-	Point<int>		mEndIndex;					/**< Index of the selected tile(s). */
+	NAS2D::Point<int>		mStartIndex;				/**< Index of the selected tile(s). */
+	NAS2D::Point<int>		mEndIndex;					/**< Index of the selected tile(s). */
 
 	bool			mLeftButtonDown = false;	/**< Flag indicating that the left mouse button is depressed. */
 	bool			mMouseOverTiles = false;	/**< Flag indicating that the mouse is actually over the tiles. */

--- a/OP2-Landlord/ToolBar.h
+++ b/OP2-Landlord/ToolBar.h
@@ -7,8 +7,6 @@
 
 #include "Pattern.h"
 
-using namespace NAS2D;
-
 
 class ToolBar
 {
@@ -48,7 +46,7 @@ public:
 
 	const Pattern& brush() const { return mBrush; }
 
-	const Rectangle<int> flood_tool_extended_area() const { return mFloodFillExtendedArea; }
+	const NAS2D::Rectangle<int> flood_tool_extended_area() const { return mFloodFillExtendedArea; }
 
 	int height();
 
@@ -80,14 +78,14 @@ private:
 	void btnExit_Clicked();
 
 private:
-	const Font mFont;
+	const NAS2D::Font mFont;
 
-	Image			mToggle;
+	NAS2D::Image			mToggle;
 
 	Pattern			mBrush;
 
 	// PRIMITIVES
-	Rectangle<int>	mFloodFillExtendedArea;
+	NAS2D::Rectangle<int>	mFloodFillExtendedArea;
 
 	// UI ELEMENTS
 	Button			btnSave;

--- a/OP2-Landlord/UIContainer.cpp
+++ b/OP2-Landlord/UIContainer.cpp
@@ -2,6 +2,10 @@
 
 #include <iostream>
 
+
+using namespace NAS2D;
+
+
 /**
  * C'tor
  */

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -27,7 +27,7 @@ Window::~Window()
 
 void Window::titleFont(const Font& font)
 {
-	mBoldFont = &font;
+	mTitleFont = &font;
 }
 
 
@@ -101,9 +101,9 @@ void Window::update()
 	r.drawBoxFilled({rect().x, rect().y, rect().width, TITLE_BAR_HEIGHT}, NAS2D::Color{75, 95, 130});
 	r.drawBox(rect(), NAS2D::Color::Black);
 
-	if (mBoldFont)
+	if (mTitleFont)
 	{
-		r.drawText(*mBoldFont, text(), {rect().x + (rect().width / 2) - (mBoldFont->width(text()) / 2), rect().y + 2});
+		r.drawText(*mTitleFont, text(), {rect().x + (rect().width / 2) - (mTitleFont->width(text()) / 2), rect().y + 2});
 	}
 
 	draw();

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -2,14 +2,13 @@
 
 #include <NAS2D/NAS2D.h>
 
-using namespace NAS2D;
 
 const int TITLE_BAR_HEIGHT = 20;
 
 
 Window::Window()
 {
-	EventHandler& e = Utility<EventHandler>::get();
+	auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
 	e.mouseButtonDown().connect({this, &Window::onMouseDown});
 	e.mouseButtonUp().connect({this, &Window::onMouseUp});
 	e.mouseMotion().connect({this, &Window::onMouseMotion});
@@ -18,14 +17,14 @@ Window::Window()
 
 Window::~Window()
 {
-	EventHandler& e = Utility<EventHandler>::get();
+	auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
 	e.mouseButtonDown().disconnect({this, &Window::onMouseDown});
 	e.mouseButtonUp().disconnect({this, &Window::onMouseUp});
 	e.mouseMotion().disconnect({this, &Window::onMouseMotion});
 }
 
 
-void Window::titleFont(const Font& font)
+void Window::titleFont(const NAS2D::Font& font)
 {
 	mTitleFont = &font;
 }
@@ -46,7 +45,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<i
 	
 	mouseDown(button, position);
 
-	if((button != EventHandler::MouseButton::Left)) { return; }
+	if((button != NAS2D::EventHandler::MouseButton::Left)) { return; }
 
 	const auto windowBounds = rect().to<int>();
 	const auto titleBarBounds = NAS2D::Rectangle{windowBounds.x, windowBounds.y, windowBounds.width, titleBarHeight()};
@@ -71,7 +70,7 @@ void Window::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int
 	
 	mouseUp(button, position);
 
-	if((button != EventHandler::MouseButton::Left)) { return; }
+	if((button != NAS2D::EventHandler::MouseButton::Left)) { return; }
 }
 
 
@@ -95,7 +94,7 @@ void Window::update()
 {
 	if (!visible()) { return; }
 
-	Renderer& r = Utility<Renderer>::get();
+	auto& r = NAS2D::Utility<NAS2D::Renderer>::get();
 
 	r.drawBoxFilled(rect(), NAS2D::Color{180, 180, 180});
 	r.drawBoxFilled({rect().x, rect().y, rect().width, TITLE_BAR_HEIGHT}, NAS2D::Color{75, 95, 130});

--- a/OP2-Landlord/Window.cpp
+++ b/OP2-Landlord/Window.cpp
@@ -52,7 +52,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<i
 	const auto titleBarBounds = NAS2D::Rectangle{windowBounds.x, windowBounds.y, windowBounds.width, titleBarHeight()};
 	if (titleBarBounds.contains(position))
 	{
-		mDragging = true;
+		mIsWindowDragging = true;
 		return;
 	}
 
@@ -65,7 +65,7 @@ void Window::onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<i
 
 void Window::onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position)
 {
-	mDragging = false;
+	mIsWindowDragging = false;
 
 	if (!visible()) { return; }
 	
@@ -83,7 +83,7 @@ void Window::onMouseMotion(NAS2D::Point<int> mousePosition, NAS2D::Vector<int> c
 
 	mouseMotion(mousePosition, change);
 
-	if (mDragging)
+	if (mIsWindowDragging)
 	{
 		position(positionX() + change.x, positionY() + change.y);
 		return;

--- a/OP2-Landlord/Window.h
+++ b/OP2-Landlord/Window.h
@@ -9,7 +9,7 @@ public:
 	Window();
 	virtual ~Window();
 
-	bool dragging() const { return mDragging; }
+	bool dragging() const { return mIsWindowDragging; }
 
 	virtual bool responding_to_events() const { return dragging(); }
 
@@ -40,5 +40,5 @@ private:
 
 	Point<int>	mMouseCoords;					/**<  */
 
-	bool		mDragging = false;				/**< Window is being dragged. */
+	bool		mIsWindowDragging = false;				/**< Window is being dragged. */
 };

--- a/OP2-Landlord/Window.h
+++ b/OP2-Landlord/Window.h
@@ -36,9 +36,7 @@ private:
 	Window& operator=(const Window&) = delete;
 
 private:
-	const Font*		mTitleFont = nullptr;
-
-	Point<int>	mMouseCoords;
-
-	bool		mIsWindowDragging = false;
+	const Font* mTitleFont = nullptr;
+	Point<int> mMouseCoords;
+	bool mIsWindowDragging = false;
 };

--- a/OP2-Landlord/Window.h
+++ b/OP2-Landlord/Window.h
@@ -23,22 +23,22 @@ protected:
 	virtual void onMouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) final;
 	virtual void onMouseMotion(NAS2D::Point<int> position, NAS2D::Vector<int> change) final;
 
-	virtual void draw() = 0;	/**< Derived types must override this. */
+	virtual void draw() = 0;
 
 	virtual void mouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) {};
 	virtual void mouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) {};
 	virtual void mouseMotion(NAS2D::Point<int> position, NAS2D::Vector<int> change) {};
 
-	Point<int>& _mouseCoords() { return mMouseCoords; }	/**< Internal function for derived types. */
+	Point<int>& _mouseCoords() { return mMouseCoords; }
 
 private:
-	Window(const Window&) = delete;				/**< Not allowed */
-	Window& operator=(const Window&) = delete;	/**< Not allowed */
+	Window(const Window&) = delete;
+	Window& operator=(const Window&) = delete;
 
 private:
-	const Font*		mTitleFont = nullptr;			/**< Font used for window title. */
+	const Font*		mTitleFont = nullptr;
 
-	Point<int>	mMouseCoords;					/**<  */
+	Point<int>	mMouseCoords;
 
-	bool		mIsWindowDragging = false;				/**< Window is being dragged. */
+	bool		mIsWindowDragging = false;
 };

--- a/OP2-Landlord/Window.h
+++ b/OP2-Landlord/Window.h
@@ -36,7 +36,7 @@ private:
 	Window& operator=(const Window&) = delete;	/**< Not allowed */
 
 private:
-	const Font*		mBoldFont = nullptr;			/**< Font used for window title. */
+	const Font*		mTitleFont = nullptr;			/**< Font used for window title. */
 
 	Point<int>	mMouseCoords;					/**<  */
 

--- a/OP2-Landlord/Window.h
+++ b/OP2-Landlord/Window.h
@@ -13,7 +13,7 @@ public:
 
 	virtual bool responding_to_events() const { return dragging(); }
 
-	void titleFont(const Font& font);
+	void titleFont(const NAS2D::Font& font);
 	int titleBarHeight() const;
 
 	virtual void update();
@@ -29,14 +29,14 @@ protected:
 	virtual void mouseUp(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) {};
 	virtual void mouseMotion(NAS2D::Point<int> position, NAS2D::Vector<int> change) {};
 
-	Point<int>& _mouseCoords() { return mMouseCoords; }
+	NAS2D::Point<int>& _mouseCoords() { return mMouseCoords; }
 
 private:
 	Window(const Window&) = delete;
 	Window& operator=(const Window&) = delete;
 
 private:
-	const Font* mTitleFont = nullptr;
-	Point<int> mMouseCoords;
+	const NAS2D::Font* mTitleFont = nullptr;
+	NAS2D::Point<int> mMouseCoords;
 	bool mIsWindowDragging = false;
 };

--- a/OP2-Landlord/main.cpp
+++ b/OP2-Landlord/main.cpp
@@ -23,6 +23,9 @@
 #endif
 
 
+using namespace NAS2D;
+
+
 int main(int argc, char *argv[])
 {
 	// Save for later


### PR DESCRIPTION
The blanket `using namespace NAS2D;` in header files was causing issues with the latest NAS2D update. A `Window` class was added to NAS2D, which caused ambiguity with the `Window` class defined in OP2-Landlord when the full `NAS2D` namespace was imported.

Reference: https://github.com/lairworks/nas2d-core/pull/1058, https://github.com/lairworks/nas2d-core/issues/701
