### PR TITLE
Add warning flag `-Wfloat-conversion`

### DIFF
--- a/OP2-Landlord/Button.cpp
+++ b/OP2-Landlord/Button.cpp
@@ -140,32 +140,34 @@ void Button::draw()
 
 	Renderer& r = Utility<Renderer>::get();
 
+	const auto& intRect = rect().to<int>();
+
 	if (mState == STATE_NORMAL)
 	{
-		bevelBox(rect().x, rect().y, rect().width, rect().height, false);
+		bevelBox(intRect.x, intRect.y, intRect.width, intRect.height, false);
 	}
 	else //(mState == STATE_PRESSED)
 	{
-		bevelBox(rect().x, rect().y, rect().width, rect().height, true);
+		bevelBox(intRect.x, intRect.y, intRect.width, intRect.height, true);
 	}
 
 
 	if (mImage)
 	{
-		int x = static_cast<int>(rect().x + (rect().width / 2) - ((mImage->size().x / 2) + 1));
-		int y = static_cast<int>(rect().y + (rect().height / 2) - (mImage->size().y / 2));
+		int x = intRect.x + (intRect.width / 2) - ((mImage->size().x / 2) + 1);
+		int y = intRect.y + (intRect.height / 2) - (mImage->size().y / 2);
 
 		if (mState == STATE_PRESSED) { ++x; ++y; }
 		r.drawImage(*mImage, NAS2D::Point{x, y});
 	}
 	else if (fontSet() && !text().empty())
 	{
-		int x = static_cast<int>(rect().x + (rect().width / 2) - (font().width(text()) / 2));
-		int y = static_cast<int>(rect().y + (rect().height / 2) - (font().height() / 2));
+		int x = intRect.x + (intRect.width / 2) - (font().width(text()) / 2);
+		int y = intRect.y + (intRect.height / 2) - (font().height() / 2);
 
 		if (mState == STATE_PRESSED) { ++x; ++y; }
 		r.drawText(font(), text(), NAS2D::Point{x, y}, NAS2D::Color::Black);
 	}
 
-	if (!enabled()) { r.drawBoxFilled(rect(), NAS2D::Color{125, 125, 125, 100}); }
+	if (!enabled()) { r.drawBoxFilled(intRect, NAS2D::Color{125, 125, 125, 100}); }
 }

--- a/OP2-Landlord/Button.cpp
+++ b/OP2-Landlord/Button.cpp
@@ -154,19 +154,17 @@ void Button::draw()
 
 	if (mImage)
 	{
-		int x = intRect.x + (intRect.width / 2) - ((mImage->size().x / 2) + 1);
-		int y = intRect.y + (intRect.height / 2) - (mImage->size().y / 2);
+		auto point = intRect.startPoint() + (intRect.size() - mImage->size()) / 2 - Vector{1, 0};
 
-		if (mState == STATE_PRESSED) { ++x; ++y; }
-		r.drawImage(*mImage, NAS2D::Point{x, y});
+		if (mState == STATE_PRESSED) { point += Vector{1, 1}; }
+		r.drawImage(*mImage, point);
 	}
 	else if (fontSet() && !text().empty())
 	{
-		int x = intRect.x + (intRect.width / 2) - (font().width(text()) / 2);
-		int y = intRect.y + (intRect.height / 2) - (font().height() / 2);
+		auto point = intRect.startPoint() + (intRect.size() - font().size(text())) / 2;
 
-		if (mState == STATE_PRESSED) { ++x; ++y; }
-		r.drawText(font(), text(), NAS2D::Point{x, y}, NAS2D::Color::Black);
+		if (mState == STATE_PRESSED) { point += Vector{1, 1}; }
+		r.drawText(font(), text(), point, NAS2D::Color::Black);
 	}
 
 	if (!enabled()) { r.drawBoxFilled(intRect, NAS2D::Color{125, 125, 125, 100}); }

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -252,11 +252,11 @@ void ListBox::onMouseWheel(NAS2D::Vector<int> change)
 }
 
 
-void ListBox::slideChanged(double _position)
+void ListBox::slideChanged(float _position)
 {
 	_checkSlider();
 
 	int pos = static_cast<int>(_position);
 	if (static_cast<float>(pos) != _position)
-		mSlider.thumbPosition(static_cast<double>(pos));
+		mSlider.thumbPosition(static_cast<float>(pos));
 }

--- a/OP2-Landlord/ListBox.cpp
+++ b/OP2-Landlord/ListBox.cpp
@@ -187,10 +187,10 @@ void ListBox::_checkSlider()
 		{
 			mSlider.length(mItems.size() - mDisplayLines);
 			mSlider.visible(true);
-			mCurrentOffset = mSlider.thumbPosition();
+			mCurrentOffset = static_cast<int>(mSlider.thumbPosition());
 			mItemMin = mCurrentOffset;
 			mItemMax = mCurrentOffset + mDisplayLines;
-			mItemWidth = rect().width - mSlider.rect().width;
+			mItemWidth = static_cast<int>(rect().width - mSlider.rect().width);
 		}
 	}
 	else

--- a/OP2-Landlord/ListBox.h
+++ b/OP2-Landlord/ListBox.h
@@ -49,7 +49,7 @@ protected:
 	virtual void onMouseDown(NAS2D::EventHandler::MouseButton button, NAS2D::Point<int> position) final;
 	virtual void onMouseMove(NAS2D::Point<int> position, NAS2D::Vector<int> change) final;
 	void onMouseWheel(NAS2D::Vector<int> change);
-	void slideChanged(double _position);
+	void slideChanged(float _position);
 
 	virtual void onFontChanged();
 

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -307,13 +307,13 @@ void Slider::draw()
 
 		if (mSliderType == SLIDER_VERTICAL)
 		{
-			_x = mSlideBar.x + mSlideBar.width + 2;
+			_x = static_cast<int>(mSlideBar.x + mSlideBar.width + 2);
 			_y = mMouseY - _h;
 		}
 		else
 		{
 			_x = mMouseX + 2;
-			_y = mSlideBar.y - 2 - _h;
+			_y = static_cast<int>(mSlideBar.y) - 2 - _h;
 		}
 
 		r.drawBox(NAS2D::Rectangle{_x - _w / 2, _y, _w, _h}, NAS2D::Color{255, 255, 255, 180});

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -109,7 +109,7 @@ void Slider::logic()
 /*!
  * Get internal slider position.
  */
-double Slider::positionInternal()
+float Slider::positionInternal()
 {
 	return mPosition;
 }
@@ -118,9 +118,9 @@ double Slider::positionInternal()
 /**
  *  \brief set internal slider position
  */
-void Slider::positionInternal(double _pos)
+void Slider::positionInternal(float _pos)
 {
-	mPosition = std::clamp(_pos, 0.0, mLength);
+	mPosition = std::clamp(_pos, 0.0f, mLength);
 }
 
 
@@ -326,7 +326,7 @@ void Slider::draw()
 /**
  * Set the current value
  */
-void Slider::thumbPosition(double value)
+void Slider::thumbPosition(float value)
 {
 	if (mBackward) { value = mLength - value; }
 
@@ -339,9 +339,9 @@ void Slider::thumbPosition(double value)
 /**
 * Gets the current value of position
 */
-double Slider::thumbPosition()
+float Slider::thumbPosition()
 {
-	double value = mPosition;
+	float value = mPosition;
 	if (mBackward) { value = mLength - value; }
 
 	return value;
@@ -354,7 +354,7 @@ double Slider::thumbPosition()
  * \param	change	Amount to change in percent to change the
  *					slider's position. Must be between 0.0 1.0.
  */
-void Slider::changeThumbPosition(double change)
+void Slider::changeThumbPosition(float change)
 {
 	positionInternal(mPosition + change);
 	mCallback(thumbPosition());
@@ -364,7 +364,7 @@ void Slider::changeThumbPosition(double change)
 /**
  * Returns the max value position can get
  */
-double Slider::length()
+float Slider::length()
 {
 	return mLength;
 }
@@ -373,7 +373,7 @@ double Slider::length()
 /**
  * Set the max value position can get
  */
-void Slider::length(double newLength)
+void Slider::length(float newLength)
 {
 	mLength = newLength;
 }

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -245,7 +245,6 @@ void Slider::draw()
 	Renderer& r = Utility<Renderer>::get();
 	std::string textHover;
 	int _x = 0, _y = 0, _w = 0, _h = 0;
-	float _thumbPosition = 0.0f;
 
 	r.drawBoxFilled({mSlideBar.x - 0.5f, mSlideBar.y, mSlideBar.width, mSlideBar.height}, NAS2D::Color{100, 100, 100});
 	r.drawBox({mSlideBar.x - 0.5f, mSlideBar.y, mSlideBar.width, mSlideBar.height}, NAS2D::Color{50, 50, 50});
@@ -274,10 +273,10 @@ void Slider::draw()
 			mSlider.height = mSlider.width;
 		}
 
-		_thumbPosition = (mSlideBar.height - mSlider.height)  * (mPosition / mLenght); //relative width
+		const auto thumbPosition = ((mSlideBar.height - mSlider.height) * mPosition) / mLenght; //relative width
 
 		mSlider.x = mSlideBar.x;
-		mSlider.y = mSlideBar.y + _thumbPosition;
+		mSlider.y = mSlideBar.y + thumbPosition;
 	}
 	else
 	{
@@ -290,9 +289,9 @@ void Slider::draw()
 			mSlider.width = mSlider.height;
 		}
 
-		_thumbPosition = (mSlideBar.width - mSlider.width)  * (mPosition / mLenght); //relative width
+		const auto thumbPosition = ((mSlideBar.width - mSlider.width) * mPosition) / mLenght; //relative width
 
-		mSlider.x = mSlideBar.x + _thumbPosition;
+		mSlider.x = mSlideBar.x + thumbPosition;
 		mSlider.y = mSlideBar.y;
 	}
 

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -372,7 +372,7 @@ double Slider::length()
 /**
  * Set the max value position can get
  */
-void Slider::length(double _lenght)
+void Slider::length(double newLength)
 {
-	mLength = _lenght;
+	mLength = newLength;
 }

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -120,7 +120,7 @@ double Slider::positionInternal()
  */
 void Slider::positionInternal(double _pos)
 {
-	mPosition = std::clamp(_pos, 0.0, mLenght);
+	mPosition = std::clamp(_pos, 0.0, mLength);
 }
 
 
@@ -210,7 +210,7 @@ void Slider::onMouseMotion(NAS2D::Point<int> position, NAS2D::Vector<int> change
 			return;
 		}
 
-		positionInternal(mLenght * ((position.y - mSlideBar.y) / mSlideBar.height));
+		positionInternal(mLength * ((position.y - mSlideBar.y) / mSlideBar.height));
 		mCallback(thumbPosition());
 	}
 	else
@@ -220,7 +220,7 @@ void Slider::onMouseMotion(NAS2D::Point<int> position, NAS2D::Vector<int> change
 			return;
 		}
 
-		positionInternal(mLenght * (position.x - mSlideBar.x) / mSlideBar.width);
+		positionInternal(mLength * (position.x - mSlideBar.x) / mSlideBar.width);
 		mCallback(thumbPosition());
 	}
 }
@@ -267,13 +267,13 @@ void Slider::draw()
 	{
 		// Slider
 		mSlider.width = mSlideBar.width; // height = slide bar height
-		mSlider.height = static_cast<int>(mSlideBar.height / mLenght); //relative width
+		mSlider.height = static_cast<int>(mSlideBar.height / mLength); //relative width
 		if (mSlider.height < mSlider.width) // not too relative. Minimum = Height itself
 		{
 			mSlider.height = mSlider.width;
 		}
 
-		const auto thumbPosition = ((mSlideBar.height - mSlider.height) * mPosition) / mLenght; //relative width
+		const auto thumbPosition = ((mSlideBar.height - mSlider.height) * mPosition) / mLength; //relative width
 
 		mSlider.x = mSlideBar.x;
 		mSlider.y = mSlideBar.y + thumbPosition;
@@ -282,14 +282,14 @@ void Slider::draw()
 	{
 		// Slider
 		mSlider.height = mSlideBar.height;	// height = slide bar height
-		mSlider.width = static_cast<int>(mSlideBar.width / (mLenght + 1)); //relative width
+		mSlider.width = static_cast<int>(mSlideBar.width / (mLength + 1)); //relative width
 		
 		if (mSlider.width < mSlider.height)	// not too relative. Minimum = Heigt itself
 		{
 			mSlider.width = mSlider.height;
 		}
 
-		const auto thumbPosition = ((mSlideBar.width - mSlider.width) * mPosition) / mLenght; //relative width
+		const auto thumbPosition = ((mSlideBar.width - mSlider.width) * mPosition) / mLength; //relative width
 
 		mSlider.x = mSlideBar.x + thumbPosition;
 		mSlider.y = mSlideBar.y;
@@ -300,7 +300,7 @@ void Slider::draw()
 
 	if (fontSet() && mDisplayPosition && mMouseHoverSlide)
 	{
-		textHover = std::to_string(static_cast<int>(thumbPosition())) + " / " + std::to_string(static_cast<int>(mLenght));
+		textHover = std::to_string(static_cast<int>(thumbPosition())) + " / " + std::to_string(static_cast<int>(mLength));
 		_w = font().width(textHover) + 4;
 		_h = font().height() + 4;
 
@@ -327,7 +327,7 @@ void Slider::draw()
  */
 void Slider::thumbPosition(double value)
 {
-	if (mBackward) { value = mLenght - value; }
+	if (mBackward) { value = mLength - value; }
 
 	positionInternal(value);
 
@@ -341,7 +341,7 @@ void Slider::thumbPosition(double value)
 double Slider::thumbPosition()
 {
 	double value = mPosition;
-	if (mBackward) { value = mLenght - value; }
+	if (mBackward) { value = mLength - value; }
 
 	return value;
 }
@@ -365,7 +365,7 @@ void Slider::changeThumbPosition(double change)
  */
 double Slider::length()
 {
-	return mLenght;
+	return mLength;
 }
 
 
@@ -374,5 +374,5 @@ double Slider::length()
  */
 void Slider::length(double _lenght)
 {
-	mLenght = _lenght;
+	mLength = _lenght;
 }

--- a/OP2-Landlord/Slider.cpp
+++ b/OP2-Landlord/Slider.cpp
@@ -295,7 +295,8 @@ void Slider::draw()
 		mSlider.y = mSlideBar.y;
 	}
 
-	bevelBox(mSlider.x, mSlider.y, mSlider.width, mSlider.height);
+	const auto intRect = mSlider.to<int>();
+	bevelBox(intRect.x, intRect.y, intRect.width, intRect.height);
 
 
 	if (fontSet() && mDisplayPosition && mMouseHoverSlide)

--- a/OP2-Landlord/Slider.h
+++ b/OP2-Landlord/Slider.h
@@ -21,21 +21,21 @@
 class Slider : public Control
 {
 public:
-	typedef NAS2D::Signal<double> ValueChangedCallback; /*!< type for Callback on value changed. */
+	typedef NAS2D::Signal<float> ValueChangedCallback; /*!< type for Callback on value changed. */
 
 public:
 	Slider();
 	virtual ~Slider();
 
-	void thumbPosition(double value);		/*!< Set the current position. */
-	double thumbPosition();					/*!< Get the current position. */
-	void changeThumbPosition(double change);/*!< Adds the change amount to the current position. */
+	void thumbPosition(float value);		/*!< Set the current position. */
+	float thumbPosition();					/*!< Get the current position. */
+	void changeThumbPosition(float change);/*!< Adds the change amount to the current position. */
 
 	bool displayPosition() { return mDisplayPosition; }			/*!< Get the position display flag. */
 	void displayPosition(bool _d) { mDisplayPosition = _d; }	/*!< Set the position display flag. */
 
-	double length(); 			/*!< Get the max value for the slide area. */
-	void length(double _lengh);	/*!< Set the max value for the slide area. */
+	float length(); 			/*!< Get the max value for the slide area. */
+	void length(float _lengh);	/*!< Set the max value for the slide area. */
 
 	bool backward() { return mBackward; }	 	/*!< Get the backward flag. */
 	void backward(bool _b) { mBackward = _b; } 	/*!< Set the backward flag. */
@@ -65,8 +65,8 @@ private:
 	Slider(const Slider&) = delete;				/**< Not allowed */
 	Slider& operator=(const Slider&) = delete;	/**< Not allowed */
 
-	double positionInternal();
-	void positionInternal(double _pos);
+	float positionInternal();
+	void positionInternal(float _pos);
 
 	virtual void positionChanged(float dX, float dY);
 
@@ -96,8 +96,8 @@ private:
 	bool					mButton2Held = false;		/**< Flag indicating that a button is being held down. */
 
 	// Slider values
-	double					mPosition = 0;				/*!< Current value that represent the position of the slider. */
-	double					mLength = 0;				/*!< Maximum value for the position of the slider. */
+	float					mPosition = 0;				/*!< Current value that represent the position of the slider. */
+	float					mLength = 0;				/*!< Maximum value for the position of the slider. */
 
 	bool					mBackward = false;			/*!< Does the value returned in backward mode . */
 

--- a/OP2-Landlord/Slider.h
+++ b/OP2-Landlord/Slider.h
@@ -97,7 +97,7 @@ private:
 
 	// Slider values
 	double					mPosition = 0;				/*!< Current value that represent the position of the slider. */
-	double					mLenght = 0;				/*!< Maximum value for the position of the slider. */
+	double					mLength = 0;				/*!< Maximum value for the position of the slider. */
 
 	bool					mBackward = false;			/*!< Does the value returned in backward mode . */
 

--- a/OP2-Landlord/TileGroups.cpp
+++ b/OP2-Landlord/TileGroups.cpp
@@ -54,7 +54,7 @@ void TileGroups::map(MapFile* map)
 }
 
 
-void TileGroups::mSlider_Changed(double pos)
+void TileGroups::mSlider_Changed(float pos)
 {
 	mTileGroupIndex = static_cast<int>(pos);
 }

--- a/OP2-Landlord/TileGroups.cpp
+++ b/OP2-Landlord/TileGroups.cpp
@@ -49,7 +49,7 @@ void TileGroups::map(MapFile* map)
 	mSlider.font(font());
 	mSlider.position(positionX() + 5, positionY() + height() - 20);
 	mSlider.size(width() - 10, 15);
-	mSlider.length((double)mMap->tileGroupCount() - 1);
+	mSlider.length(mMap->tileGroupCount() - 1);
 	mSlider.displayPosition(true);
 }
 

--- a/OP2-Landlord/TileGroups.cpp
+++ b/OP2-Landlord/TileGroups.cpp
@@ -79,7 +79,8 @@ void TileGroups::draw()
 {
 	Renderer& r = Utility<Renderer>::get();
 
-	mMap->tileGroup(mTileGroupIndex)->draw(rect().x + 5, rect().y + titleBarHeight() + 5);
+	const auto point = rect().startPoint().to<int>() + Vector{5, 5 + titleBarHeight()};
+	mMap->tileGroup(mTileGroupIndex)->draw(point.x, point.y);
 
 	r.drawText(font(), mMap->tileGroupName(mTileGroupIndex), {positionX() + 10, positionY() + titleBarHeight() + 10});
 

--- a/OP2-Landlord/TileGroups.h
+++ b/OP2-Landlord/TileGroups.h
@@ -38,7 +38,7 @@ private:
 
 	virtual void positionChanged(float dX, float dY);
 
-	void mSlider_Changed(double);
+	void mSlider_Changed(float);
 
 private:
 	int			mTileGroupIndex = 0;		/**<  */

--- a/makefile
+++ b/makefile
@@ -10,7 +10,8 @@ config := default
 
 
 CPPFLAGS := -Inas2d-core/
-CXXFLAGS := -std=c++20 -g -Wall -Wno-unknown-pragmas $(shell sdl2-config --cflags)
+CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas
+CXXFLAGS := -std=c++20 -g $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := -static-libgcc -static-libstdc++ -Lnas2d-core/lib/
 LDLIBS := -lstdc++fs -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lGL -lGLEW
 

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ config := default
 
 
 CPPFLAGS := -Inas2d-core/
-CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas
+CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas -Wfloat-conversion
 CXXFLAGS := -std=c++20 -g $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := -static-libgcc -static-libstdc++ -Lnas2d-core/lib/
 LDLIBS := -lstdc++fs -lnas2d -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lGL -lGLEW


### PR DESCRIPTION
There is some work being done to update for Visual Studio 2022. Visual Studio 2022 seems to complain about `int`/`float` conversions by default. Better to enable the equivalent warning flag on Linux so these problems can be caught early cross platform.

Edit: Just noticed AppVeyor builds were already warning about the conversions. It's just that we never enabled `/warnAsError` for AppVeyor builds, so the builds never failed because of them. We can potentially still upgrade to the GitHub Actions workflow, we just need to remove the `/warnAsError` flag.
