### PR TITLE
Adjust texture size to avoid textures that are way too large for a given tileset

### DIFF
--- a/OP2-Landlord/Graphics.cpp
+++ b/OP2-Landlord/Graphics.cpp
@@ -119,9 +119,10 @@ Graphics::Texture Graphics::loadTexturePacked(const void* buffer, const size_t b
 {  
     SdlSurface src{ SDL_ConvertSurfaceFormat(createSurfaceFromBuffer(buffer, buffersize).get(), SDL_PIXELFORMAT_RGB888, 0) };
 
+    const int textureSize = src->h / 32 > 256 ? 1024 : 512;
     SdlSurface destinationSurface(SDL_CreateRGBSurface(
         src.get()->flags,
-        1024, 1024,
+        textureSize, textureSize / 2,
         src->format->BitsPerPixel,
         src->format->Rmask,
         src->format->Gmask,


### PR DESCRIPTION
This is a bit of a brute force method. I noticed during generation that no tileset requires a texture size larger than half height of its width.

There is still a lot of room for improvement. A really good option would be to generate a single texture to use as an atlas, bake all of the tiles into the single larger texture and attach some metadata to it to know which tileset (WELLXXXX) begins where in the atlas.

This is all done in memory and has no effect on the stored tilesets.