### PR TITLE
Update `git` submodule URLs to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "OP2Utility"]
 	path = OP2Utility
-	url = git@github.com:OutpostUniverse/OP2Utility.git
+	url = https://github.com/OutpostUniverse/OP2Utility.git
 [submodule "json"]
 	path = json
-	url = git@github.com:nlohmann/json.git
+	url = https://github.com/nlohmann/json.git


### PR DESCRIPTION
Not everybody has a GitHub SSH key installed, so trying to connect using a `git` URL (SSH) will fail.

Using SSH based URLs can cause failures both locally and for CI builds.

----

To propagate the change from `.gitmodules` to the submodules themselves, run:
```sh
git submodule sync
```

----

The current CI build errors are for other long standing issues with the CI builds that have yet to be fixed. This change fixes one of the problems.

----

Related:
- Issue #96
