### PR TITLE
Update Actions used in workflow to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,16 +22,16 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Checkout NAS2D
       run: git submodule update --init nas2d-core/
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v3
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache@v2
+      uses: actions/cache@v5
       id: cache
       with:
         path: C:\vcpkg\installed\


### PR DESCRIPTION
Fix error:
> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

There are a number of other structural problems with the GitHub Actions workflows that cause them to fail. This fixes the first of them, allowing the others to be addressed more easily.

----

Related:
- Issue #96
