### PR TITLE
Add `.gitignore` entry for `nas2d-core/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ x64/
 /vcpkg_installed
 /*.ini
 /OP2-Landlord/*.ini
+
+# Old submodules
+nas2d-core/


### PR DESCRIPTION
This prevents `git` from seeing untracked files when switching between branches that used NAS2D as a submodule.

----

Build errors are unrelated longstanding issues that have yet to be fixed.

----

Related:
- Issue #96
