### PR TITLE
Add GitHub Actions workflow to build Docker build env

### DIFF
--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -1,0 +1,23 @@
+name: Build Docker Build Env
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dockerBuild:
+    runs-on: ubuntu-latest
+    env:
+      buildPath: dockerBuildEnv/
+      imageName: ghcr.io/outpostuniverse/op2-landlord:1.0
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Docker build
+        run: docker build "${{ env.buildPath }}" --tag "${{ env.imageName }}"
+
+      - name: Docker login
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "${{ github.repository_owner }}" --password-stdin
+
+      - name: Docker push
+        run: docker push "${{ env.imageName }}"

--- a/dockerBuildEnv/Dockerfile
+++ b/dockerBuildEnv/Dockerfile
@@ -1,0 +1,15 @@
+# For building on GitHub Actions
+
+# To update:
+# 1. Bump the version number tag on `imageName` in: `.github/workflows/buildDockerBuildEnv.yml`
+# 2. Make and push changes to Dockerfile
+# 3. Run `buildDockerBuildEnv` workflow on branch with changes
+#      https://github.com/OutpostUniverse/OP2Utility/actions/workflows/buildDockerBuildEnv.yml
+# 4. Update `.github/workflows/build.yml` workflow to use new version number tag
+
+FROM ghcr.io/outpostuniverse/op2utility:1.3
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    nlohmann-json3-dev \
+    libimgui-dev \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
It's much faster to build and upload an image from a GitHub Actions runner than to build locally and then upload from a remote connection.

To keep this simple, this workflow will only run on demand. It will need to be part of the default branch (`main`) before it can be run on demand.

The typically workflow might be to update the `Dockerfile` and the tag in the `buildDockerBuildEnv` workflow, and then run it, from the branch, to build the new image. Update the image tag used by the runners in a followup commit, and then open a PR.

Related:
- Issue #96
- PR https://github.com/OutpostUniverse/OP2Utility/pull/446
