### PR TITLE
Fix warning about returning reference to temporary

### DIFF
--- a/OP2-Landlord/FileIo.h
+++ b/OP2-Landlord/FileIo.h
@@ -18,7 +18,7 @@ public:
 
 	const std::string& savePath() const { return mSavePath; }
 	const std::string& fileName() const { return mFileName; }
-	const std::string& fullPath() const { return mSavePath + "\\" + mFileName; }
+	std::string fullPath() const { return mSavePath + "\\" + mFileName; }
 	const std::string& folderPath() const { return mFolderPath; }
 	const std::string& pathSeparator() const { return mPathSeparator; }
 


### PR DESCRIPTION
Error reported by GCC:
> ```
> OP2-Landlord/FileIo.h: In member function ‘const std::string& FileIo::fullPath() const’:
> OP2-Landlord/FileIo.h:21:71: warning: returning reference to temporary [-Wreturn-local-addr]
>    21 |         const std::string& fullPath() const { return mSavePath + "\\" + mFileName; }
>       |                                                      ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
> ```

Closes #100

Related:
- Issue #100
- PR #105
- PR #102
