### PR TITLE
Replace MSVC specific `strcpy_s` with `std::memcpy`

### DIFF
--- a/OP2-Landlord/Gui.cpp
+++ b/OP2-Landlord/Gui.cpp
@@ -11,6 +11,8 @@
 #include "FileIo.h"
 #include "Utility.h"
 
+#include <cstring>
+
 
 Gui::Gui(StringTable& table, EditorConfig& config, Graphics& graphics, const std::string& settingsPath) :
     mStringTable{ table },
@@ -85,7 +87,8 @@ Gui::AppState Gui::initialSetup()
     {
         if (mFileIo.pickFolder())
         {
-            std::ignore = strcpy_s(op2Path, mFileIo.folderPath().c_str());
+            const auto& folderPath = mFileIo.folderPath();
+            std::ignore = std::memcpy(op2Path, folderPath.c_str(), std::min(sizeof(op2Path), folderPath.size() + 1));
         }
     }
 


### PR DESCRIPTION
Fix build error on non-Windows systems:
> ```
> OP2-Landlord/Gui.cpp: In member function ‘Gui::AppState Gui::initialSetup()’:
> OP2-Landlord/Gui.cpp:88:27: error: ‘strcpy_s’ was not declared in this scope; did you mean ‘strcpy’?
>    88 |             std::ignore = strcpy_s(op2Path, mFileIo.folderPath().c_str());
>       |                           ^~~~~~~~
>       |                           strcpy
> ```

Make use of `std::string` internal buffer being null terminated, and ensure we copy the null terminator which is not included in `size()`. Never copy more than the lower of the buffer size or the source string length.

Closes #106

Related:
- Issue #106
- Issue #96
- PR #108
- PR #105
- PR #102
