### PR TITLE
Update `.gitignore` for submodules on other branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Debug/
 x64/
 .vs/
 *.user
+
+# Submodules for other branches
+OP2Utility/


### PR DESCRIPTION
Related:
- Issue #96
