### PR TITLE
Update OP2Utility for disabling Vcpkg for main library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         VcpkgManifestInstall: true
       run: |
-        msbuild /target:OP2-Landlord:VcpkgInstallManifestDependencies
+        msbuild /target:VcpkgInstallManifestDependencies
 
     - name: Save vcpkg dependency cache
       uses: actions/cache/save@v5

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,9 +3,9 @@
 	"name": "op2-landlord",
 	"dependencies": [
 		{
-		  "name": "imgui",
-		  "default-features": false,
-		  "features": [ "freetype", "sdl2-binding", "sdl2-renderer-binding" ]
+			"name": "imgui",
+			"default-features": false,
+			"features": [ "freetype", "sdl2-binding", "sdl2-renderer-binding" ]
 		},
 		"sdl2",
 		"sdl2-image",


### PR DESCRIPTION
The main library OP2Utility has no dependencies and so doesn't need Vcpkg.

By explicitly disabling Vcpkg for OP2Utility, there will be no conflict about having a manifest file present (in the OP2-Landlord solution) and not having manifest mode enabled for OP2Utility. This allows the OP2-Landlord Windows build to remove the hack where the OP2-Landlord project needs to be explicitly specified when running the `VcpkgInstallManifestDependencies` target.

Related:
- PR https://github.com/OutpostUniverse/OP2Utility/pull/454
- Issue https://github.com/OutpostUniverse/OP2Utility/issues/414
