### PR TITLE
Update Vcpkg `builtin-baseline`

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,5 +11,5 @@
 		"sdl2-image",
 		"nlohmann-json"
 	],
-	"builtin-baseline": "1286cac8751e13bb289061b7e3b89eb4c3f613a2"
+	"builtin-baseline": "935b5c81c21f9a97a692a75728e4fc3443882937"
 }


### PR DESCRIPTION
Update to latest version before a breaking change to `imgui`.

The breaking change to `imgui` happened in (imgui repo):
> ```
> commit 5d973a87d45ac8d982e31dd1feddf32efdcbbeaa
> Author: ocornut <omarcornut@gmail.com>
> Date:   Tue May 14 19:10:31 2024 +0200
>
>     Backends: SDL_Renderer2/SDL_Renderer3: and ImGui_ImplSDLRenderer2_RenderDrawData() and ImGui_ImplSDLRenderer3_RenderDrawData() now takes a SDL_Renderer* parameter.
> ```

The last vcpkg ports update to the `imgui` package without the breaking change is:
> commit 935b5c81c21f9a97a692a75728e4fc3443882937
> Author: Rémy Tassoux <contact@rt2.fr>
> Date:   Wed May 29 10:40:48 2024 +0200
>
>     [imgui] Add test-engine feature (#38758)
>
>     Add test-engine feature to the imgui port:
>     https://github.com/ocornut/imgui_test_engine

----

Also of note is the limited range of feature support for `sdl2-binding` / `sdl2-renderer-binding`.

It appears support was first added in baseline:
`de256f1c2ece3675983576beec63243f8a8fcce7` (Date:   Wed Oct 13 23:47:17 2021 +0200)

It appears support was removed when it was replaced by SDL3 bindings in baseline:
`790b14a8802d85288d6cfe580f603018d3ec5ca0` (Date:   Tue Feb 25 05:05:21 2025 -0800)

----

Related:
- Issue #116
