### PR TITLE
Switch Vcpkg to Manifest Mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: windows-latest
     env:
       PLATFORM: ${{ matrix.platform }}
+      VcpkgManifestInstall: false
 
     steps:
     - uses: actions/checkout@v3
@@ -34,12 +35,16 @@ jobs:
       uses: actions/cache@v3
       id: cache
       with:
-        path: C:\vcpkg\installed\
-        key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('nas2d-core\InstallVcpkgDeps.bat') }}
+        path: vcpkg_installed
+        key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Install vcpkg dependencies
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nas2d-core\InstallVcpkgDeps.bat
+      env:
+        VcpkgManifestInstall: true
+      run: |
+        vcpkg integrate install
+        msbuild /target:OP2-Landlord:VcpkgInstallManifestDependencies
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -47,5 +52,5 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: |
         vcpkg integrate install
-        msbuild /maxCpuCount /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+        msbuild /maxCpuCount /property:Configuration=${{env.BUILD_CONFIGURATION}} /property:PreBuildEventUseInBuild=false /property:VcpkgEnableManifest=true ${{env.SOLUTION_FILE_PATH}}
         # msbuild /maxCpuCount /warnAsError /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/OP2-Landlord/OP2-Landlord.vcxproj
+++ b/OP2-Landlord/OP2-Landlord.vcxproj
@@ -85,6 +85,9 @@
     <IncludePath>..\nas2d-core;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "nas2d",
+  "dependencies": [
+    "glew",
+    "sdl2",
+    "sdl2-image",
+    "sdl2-ttf",
+    "sdl2-mixer",
+    "gtest"
+  ],
+  "builtin-baseline": "42452c3443af90de4b650a958e359eb1fe62f1ae"
+}


### PR DESCRIPTION
Add a `vcpkg.json` manifest file based on most recent version of NAS2D, but with an altered `builtin-baseline`.

Set `builtin-baseline` to before the upgrade of `sdl2-mixer` to `2.8.1`. Related:
- https://github.com/lairworks/nas2d-core/issues/1242

Set `VcpkgEnableManifest` to `true` in OP2-Landlord project.

Update GitHub Actions workflow to use Vcpkg in Manifest Mode.

Update GitHub Actions workflow to pass `/property` flags so NAS2D submodule will build with Manifest Mode and will disable the PreBuildEvent that tries to install Vcpkg packages in Classic Mode.

----

This is a minimal change to fix the broken CI build. It may be awkward to deal with for local builds.

The problem was the `sdl2-mixer` package installed by Vcpkg was updated to include a breaking change. Classic Mode didn't give much control over what version of a package was installed. By switching to Manifest Mode it becomes possible to set the `builtin-baseline` value, which controls which versions of packages are installed and used.

Related:
- Issue #96
- Issue https://github.com/lairworks/nas2d-core/issues/1242
- PR #103
