### PR TITLE
Update NAS2D for Vcpkg Manifest Mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,13 @@ jobs:
         path: vcpkg_installed
         key: ${{ steps.cacheRestoreVcpkg.outputs.cache-primary-key }}
 
+    - name: Copy vcpkg cache to NAS2D folder
+      run: |
+        xcopy vcpkg_installed nas2d-core\vcpkg_installed\ /s /e
+
     - name: Build
       run: |
-        msbuild /maxCpuCount /property:PreBuildEventUseInBuild=false /property:VcpkgEnableManifest=true
+        msbuild /maxCpuCount
 
   linux:
     strategy:


### PR DESCRIPTION
Update NAS2D to the point where it switched to using Vcpkg in Manifest Mode.

This allows a few custom hacks to be removed from the build workflow that prevented Vcpkg from running in Classic Mode. Instead, the manifest from the OP2-Landlord repository was used.

There is still a slight hack, in that the OP2-Landlord manifest sets a `builtin-baseline` which is absent from the NAS2D manifest. This is relevant because of a breaking change in how `sdl2-mixer` is used. The workflow handles this by only installing manifest dependencies for the OP2-Landlord manifest, and then copying those files to the NAS2D manifest install folder, and skipping running Vcpkg again for the NAS2D manifest. This means NAS2D will end up building with packages set by the `builtin-baseline` from the OP2-Landlord manifest.

Related:
- Issue #128
- PR #129
- PR https://github.com/lairworks/nas2d-core/pull/1109
- Issue github.com/lairworks/nas2d-core/issues/1242
